### PR TITLE
recipes-core: tisdk-core-bundle: Remove old chromium logic

### DIFF
--- a/recipes-core/images/tisdk-core-bundle.bbappend
+++ b/recipes-core/images/tisdk-core-bundle.bbappend
@@ -21,9 +21,6 @@ IMAGE_INSTALL:append = " \
     packagegroup-arago-tisdk-sourceipks-sdk-host \
 "
 
-# Avoid building chromium for AM65x
-IMAGE_INSTALL:remove:am65xx = "chromium"
-
 # Set DTB filters for each machine.  Use "unknown" by default to avoid
 # picking up DTB files for devices with no DTB support.
 DTB_FILTER:j721e = "j721e\|fpdlink"


### PR DESCRIPTION
Chromium now gets added in filesystem using dynamic-layers in meta-arago [1] which ensures that it is built & packaged only if meta-browser layer is included in bblayers.conf

[1]: https://git.ti.com/cgit/arago-project/meta-arago/commit/?h=scarthgap&id=9308564968a182995103c4ae263a12a91ad6215e