### PR TITLE
tisdk-default-image: matrix-gui packagegroup removed in meta-arago

### DIFF
--- a/recipes-core/images/tisdk-default-image.bbappend
+++ b/recipes-core/images/tisdk-default-image.bbappend
@@ -1,16 +1,5 @@
 PR:append = "_tisdk_5"
 
-# Holds all packagegroups that includes Matrix v2
-MATRIX_GUI_PACKAGEGROUPS = " \
-    packagegroup-arago-tisdk-matrix \
-    packagegroup-arago-tisdk-matrix-extra \
-"
-
-# Avoid building Matrix V2 for all k3 platforms
-IMAGE_INSTALL:remove:k3 = " \
-    ${MATRIX_GUI_PACKAGEGROUPS} \
-"
-
 IMAGE_INSTALL:append = " \
     packagegroup-arago-gst-sdk-target \
     resize-rootfs \


### PR DESCRIPTION
We no longer need to remove it in this layer, given that it is dropped
from meta-arago entirely [1].

[1]: https://git.ti.com/cgit/arago-project/meta-arago/commit/?h=scarthgap&id=790e63be1c03c0aace0ca784df6862ca36c7bc52

Signed-off-by: Aniket Limaye <a-limaye@ti.com>
