### PR TITLE
recipes-core: Cleanup few recipes 

### DIFF
--- a/conf/distro/include/arago-source-ipk.inc
+++ b/conf/distro/include/arago-source-ipk.inc
@@ -98,12 +98,6 @@ SRCIPK_PRESERVE_GIT:pn-trusted-firmware-a ?= "true"
 CREATE_SRCIPK:pn-pru-icss ?= "1"
 SRCIPK_INSTALL_DIR:pn-pru-icss ?= "example-applications/${PN}-${PV}"
 
-CREATE_SRCIPK:pn-matrix-gui ?= "1"
-SRCIPK_INSTALL_DIR:pn-matrix-gui ?= "example-applications/${PN}-${PV}"
-
-CREATE_SRCIPK:pn-matrix-gui-browser ?= "1"
-SRCIPK_INSTALL_DIR:pn-matrix-gui-browser ?= "example-applications/${PN}-${PV}"
-
 CREATE_SRCIPK:pn-mmwavegesture-hmi ?= "1"
 SRCIPK_INSTALL_DIR:pn-mmwavegesture-hmi ?= "example-applications/${PN}-${PV}"
 

--- a/recipes-core/images/tisdk-core-bundle.bbappend
+++ b/recipes-core/images/tisdk-core-bundle.bbappend
@@ -12,10 +12,6 @@ TARGET_IMAGES:append = " ${@oe.utils.conditional("TI_EXTRAS", "tie-jailhouse", "
 
 TARGET_IMAGE_TYPES = "tar.xz wic.xz wic.bmap"
 
-DEPLOY_IMAGES_NAME:append:k3 = " Image fitImage fitImage-its-${MACHINE}"
-DEPLOY_IMAGES_NAME:append:am335x-evm = " extlinux.conf"
-DEPLOY_IMAGES_NAME:append:am437x-evm = " extlinux.conf"
-
 # Add packagegroup to deploy sources in SDK installer
 IMAGE_INSTALL:append = " \
     packagegroup-arago-tisdk-sourceipks-sdk-host \

--- a/recipes-core/images/tisdk-default-image.bbappend
+++ b/recipes-core/images/tisdk-default-image.bbappend
@@ -1,16 +1,5 @@
 PR:append = "_tisdk_5"
 
-# Holds all packagegroups that includes Matrix v2
-MATRIX_GUI_PACKAGEGROUPS = " \
-    packagegroup-arago-tisdk-matrix \
-    packagegroup-arago-tisdk-matrix-extra \
-"
-
-# Avoid building Matrix V2 for all k3 platforms
-IMAGE_INSTALL:remove:k3 = " \
-    ${MATRIX_GUI_PACKAGEGROUPS} \
-"
-
 IMAGE_INSTALL:append = " \
     packagegroup-arago-gst-sdk-target \
     resize-rootfs \

--- a/recipes-core/images/tisdk-display-cluster-image.bb
+++ b/recipes-core/images/tisdk-display-cluster-image.bb
@@ -9,11 +9,6 @@ require recipes-core/images/tisdk-default-image.bb
 # Ensure that we build this image only for AM62P
 COMPATIBLE_MACHINE = "am62pxx"
 
-IMAGE_INSTALL:remove = " \
-    packagegroup-arago-tisdk-matrix \
-    packagegroup-arago-tisdk-matrix-extra \
-"
-
 IMAGE_INSTALL:append = " \
     packagegroup-arago-gst-sdk-target \
     resize-rootfs \

--- a/recipes-core/packagegroups/packagegroup-arago-tisdk-sourceipks-sdk-host.bb
+++ b/recipes-core/packagegroups/packagegroup-arago-tisdk-sourceipks-sdk-host.bb
@@ -41,11 +41,9 @@ UTILS:append:ti33x = " \
     mmwavegesture-hmi-src \
     evse-hmi-src \
     protection-relays-hmi-src \
-    matrix-gui-browser-src \
     refresh-screen-src \
     qt-tstat-src \
     oprofile-example-src \
-    matrix-gui-src \
     ${@bb.utils.contains('MACHINE_FEATURES', 'gpu', 'pdm-anomaly-detection-src', '', d)} \
 "
 
@@ -53,12 +51,10 @@ UTILS:append:ti43x = " \
     pru-icss-src \
     mmwavegesture-hmi-src \
     evse-hmi-src \
-    matrix-gui-browser-src \
     refresh-screen-src \
     qt-tstat-src \
     image-gallery-src \
     oprofile-example-src \
-    matrix-gui-src \
     ${@bb.utils.contains('MACHINE_FEATURES', 'gpu', 'pdm-anomaly-detection-src', '', d)} \
 "
 

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -7,7 +7,6 @@ SRC_URI:append = " \
 "
 
 do_install:append() {
-
     install -d ${D}${base_libdir}
-    install -m 0644 ${WORKDIR}/systemd-networkd-wait-online.service ${D}${base_libdir}/systemd/system/
+    install -m 0644 ${WORKDIR}/systemd-networkd-wait-online.service ${D}${systemd_unitdir}/system/
 }


### PR DESCRIPTION
Under `recipes-core/`, cleanup few recipes as a part of scarthgap migration. 