### PR TITLE
conf, recipes-core: Remove references of image-gallery in ti43x

### DIFF
--- a/conf/distro/include/arago-source-ipk.inc
+++ b/conf/distro/include/arago-source-ipk.inc
@@ -93,9 +93,6 @@ SRCIPK_INSTALL_DIR:pn-mmwavegesture-hmi ?= "example-applications/${PN}-${PV}"
 CREATE_SRCIPK:pn-evse-hmi ?= "1"
 SRCIPK_INSTALL_DIR:pn-evse-hmi ?= "example-applications/${PN}-${PV}"
 
-CREATE_SRCIPK:pn-image-gallery ?= "1"
-SRCIPK_INSTALL_DIR:pn-image-gallery ?= "example-applications/${PN}"
-
 CREATE_SRCIPK:pn-protection-relays-hmi ?= "1"
 SRCIPK_INSTALL_DIR:pn-protection-relays-hmi ?= "example-applications/${PN}-${PV}"
 

--- a/recipes-core/packagegroups/packagegroup-arago-tisdk-sourceipks-sdk-host.bb
+++ b/recipes-core/packagegroups/packagegroup-arago-tisdk-sourceipks-sdk-host.bb
@@ -49,7 +49,6 @@ UTILS:append:ti43x = " \
     pru-icss-src \
     mmwavegesture-hmi-src \
     evse-hmi-src \
-    image-gallery-src \
     oprofile-example-src \
     ${@bb.utils.contains('MACHINE_FEATURES', 'gpu', 'pdm-anomaly-detection-src', '', d)} \
 "


### PR DESCRIPTION
image-gallery was built as a part of matrix-gui.
As matrix-gui is now dropped from meta-arago [1],
the package is no longer valid & hence remove all
references of it from meta-tisdk.

[1]: https://git.ti.com/cgit/arago-project/meta-arago/commit/?h=scarthgap&id=867c14143b1b55f1c1468d079dc1b2cc8557809a