### PR TITLE
[scarthgap] Drop watchdog & kmscube

### DIFF
--- a/recipes-core/packagegroups/packagegroup-arago-tisdk-addons.bbappend
+++ b/recipes-core/packagegroups/packagegroup-arago-tisdk-addons.bbappend
@@ -15,7 +15,6 @@ DEMOS:append:am64xx = " \
 "
 
 EXTRA_PACKAGES:append = " \
-    watchdog \
     kmscube \
 "
 EXTRA_PACKAGES:remove:am64xx = "kmscube"

--- a/recipes-core/packagegroups/packagegroup-arago-tisdk-addons.bbappend
+++ b/recipes-core/packagegroups/packagegroup-arago-tisdk-addons.bbappend
@@ -14,10 +14,6 @@ DEMOS:append:am64xx = " \
     opcua-server \
 "
 
-EXTRA_PACKAGES:append = " \
-    kmscube \
-"
-EXTRA_PACKAGES:remove:am64xx = "kmscube"
 EXTRA_PACKAGES:append:ti33x = " opencv"
 EXTRA_PACKAGES:append:ti43x = " opencv"
 


### PR DESCRIPTION
watchdog & kmscube are now added as a part of [meta-arago][scarthgap].
Hence, we can safely drop these packages from meta-tisdk. 