### PR TITLE
recipes-core: Drop packagegroup-arago-base

### DIFF
--- a/recipes-core/packagegroups/packagegroup-arago-base.bbappend
+++ b/recipes-core/packagegroups/packagegroup-arago-base.bbappend
@@ -1,9 +1,0 @@
-RDEPENDS:${PN}:append = " \
-        libdrm-dev \
-        websocketd \
-        libloki \
-        boost \
-        json-c \
-"
-
-PR:append = "_tisdk_0"


### PR DESCRIPTION
All packages are already part of meta-arago.
Hence, this bbappend is no longer needed.