### PR TITLE
recipes-core: packagegroups: Package pru-icss sources in am62xx

### DIFF
--- a/recipes-core/packagegroups/packagegroup-arago-tisdk-sourceipks-sdk-host.bb
+++ b/recipes-core/packagegroups/packagegroup-arago-tisdk-sourceipks-sdk-host.bb
@@ -32,6 +32,7 @@ CRYPTO_RDEPENDS = "cryptodev-module-src"
 
 # Task to install sources for additional utilities/demos for SDKs
 UTILS = "arm-benchmarks-src"
+UTILS:append:am62xx = " pru-icss-src"
 UTILS:append:am64xx = " pru-icss-src"
 UTILS:append:am335x-evm = " pru-adc-src"
 


### PR DESCRIPTION
pru-icss in meta-ti:scarthgap is compatible for am62xx [1] Hence, package it's sources under example-applications/ of SDK installer.

[1]: https://git.ti.com/cgit/arago-project/meta-ti/tree/meta-ti-extras/recipes-bsp/pru/pru-icss_git.bb?h=10.00.03#n17