### PR TITLE
recipes-tisdk: tisdk-uenv: am62pxx-evm: Fix overlay paths based on ti-linux-6.6-y

### DIFF
--- a/recipes-tisdk/tisdk-uenv/tisdk-uenv/am62pxx-evm/uEnv-am62p-display-cluster.txt
+++ b/recipes-tisdk/tisdk-uenv/tisdk-uenv/am62pxx-evm/uEnv-am62p-display-cluster.txt
@@ -8,4 +8,4 @@
 #       variables such as bootdelay cannot be changed by this file since
 #       it is not evaluated until the bootcmd is run.
 
-uenvcmd=if test ${boot_fit} -eq 1; then  setenv name_overlays ti/k3-am62p5-sk-microtips-mf101hie-panel.dtbo ti/k3-am62p5-sk-dss-shared-mode.dtbo $name_overlays ; else; setenv name_overlays k3-am62p5-sk-microtips-mf101hie-panel.dtbo k3-am62p5-sk-dss-shared-mode.dtbo $name_overlays; fi
+name_overlays=ti/k3-am62p5-sk-microtips-mf101hie-panel.dtbo ti/k3-am62p5-sk-dss-shared-mode.dtbo


### PR DESCRIPTION
- With ti-linux-6.6-y, all overlays are now present at /boot/dtb/ti/ of root filesystem in-case of non fit-Image based boot as well. Hence, the if check is no longer valid & can be removed.