### PR TITLE
recipes-security: optee: Enable SOFTWARE PRNG

### DIFF
--- a/recipes-security/optee/optee-client_%.bbappend
+++ b/recipes-security/optee/optee-client_%.bbappend
@@ -2,4 +2,8 @@ EXTRA_OEMAKE:append:am62xx = " \
 	${@oe.utils.conditional("TI_EXTRAS", "tie-jailhouse", "CFG_WITH_SOFTWARE_PRNG=y", "", d)} \
 "
 
+EXTRA_OEMAKE:append:beagleplay = " \
+	CFG_WITH_SOFTWARE_PRNG=y \
+"
+
 PR:append = "_tisdk_4"

--- a/recipes-security/optee/optee-os_%.bbappend
+++ b/recipes-security/optee/optee-os_%.bbappend
@@ -2,4 +2,8 @@ EXTRA_OEMAKE:append:am62xx = " \
 	${@oe.utils.conditional("TI_EXTRAS", "tie-jailhouse", "CFG_WITH_SOFTWARE_PRNG=y", "", d)} \
 "
 
+EXTRA_OEMAKE:append:beagleplay = " \
+	CFG_WITH_SOFTWARE_PRNG=y \
+"
+
 PR:append = "_tisdk_5"

--- a/recipes-security/optee/optee-test_%.bbappend
+++ b/recipes-security/optee/optee-test_%.bbappend
@@ -2,4 +2,8 @@ EXTRA_OEMAKE:append:am62xx = " \
 	${@oe.utils.conditional("TI_EXTRAS", "tie-jailhouse", "CFG_WITH_SOFTWARE_PRNG=y", "", d)} \
 "
 
+EXTRA_OEMAKE:append:beagleplay = " \
+	CFG_WITH_SOFTWARE_PRNG=y \
+"
+
 PR:append = "_tisdk_4"


### PR DESCRIPTION
- Pass `CFG_WITH_SOFTWARE_PRNG=y` to EXTRA_OEMAKE which ensures that random bytes are generated
by a software implementation

- This workaround is needed for Deepsleep to work on beagleplay-gp