### PR TITLE
ti-apps-launcher: wait for dev-dri-card1 before starting on eglfs

### DIFF
--- a/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
+++ b/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
@@ -1,4 +1,4 @@
-PR = "r15"
+PR = "r16"
 
 DESCRIPTION = "ti-apps-launcher service"
 HOMEPAGE = "https://github.com/TexasInstruments/ti-apps-launcher"
@@ -25,6 +25,7 @@ SRC_URI = " \
     file://ti-apps-launcher-eglfs.service \
     file://ti-apps-launcher-analytics.service \
     file://ti-demo.service \
+    file://dev-dri-card1.rules \
     file://Usage.md \
 "
 
@@ -98,9 +99,16 @@ do_install:append() {
         install -d ${D}${systemd_system_unitdir}
         install -m 0755 ${WORKDIR}/ti-demo.service ${D}${systemd_system_unitdir}/ti-demo.service
     fi
+
+    if [ "${SERVICE_SUFFIX}" == "-eglfs" ]; then
+        install -d ${D}${sysconfdir}/udev/rules.d
+        install -m 0644 ${WORKDIR}/dev-dri-card1.rules ${D}${sysconfdir}/udev/rules.d/
+    fi
+
 }
 
 FILES:${PN} += " \
     ${bindir}/${APP_NAME} \
     /opt/${APP_NAME}/ \
+    ${sysconfdir} \
 "

--- a/recipes-demos/ti-apps-launcher/ti-apps-launcher/dev-dri-card1.rules
+++ b/recipes-demos/ti-apps-launcher/ti-apps-launcher/dev-dri-card1.rules
@@ -1,0 +1,1 @@
+ENV{DEVNAME}=="/dev/dri/card1", TAG+="systemd"

--- a/recipes-demos/ti-apps-launcher/ti-apps-launcher/ti-apps-launcher-eglfs.service
+++ b/recipes-demos/ti-apps-launcher/ti-apps-launcher/ti-apps-launcher-eglfs.service
@@ -4,6 +4,9 @@
 [Unit]
 Description=ti-apps-launcher service
 
+Wants=dev-dri-card1.device
+After=dev-dri-card1.device
+
 [Service]
 # Requires systemd-notify.so Weston plugin.
 Type=simple


### PR DESCRIPTION
On eglfs based systems, the ti-apps-launcher is starting before the display and gpu cards are enumerated resulting in blank screen and crashes. So add a udev rule for /dev/dri/card1 and wait for it before starting apps on eglfs.