### PR TITLE
recipes-core: packagegroups: Drop SGX sources from am65xx

### DIFF
--- a/recipes-core/packagegroups/packagegroup-arago-tisdk-sourceipks-sdk-host.bb
+++ b/recipes-core/packagegroups/packagegroup-arago-tisdk-sourceipks-sdk-host.bb
@@ -22,9 +22,10 @@ GRAPHICS_RDEPENDS:remove:am62axx = "${@bb.utils.contains('MACHINE_FEATURES','gpu
 # Remove GPU driver sources for am64xx
 GRAPHICS_RDEPENDS:remove:am64xx = "${@bb.utils.contains('MACHINE_FEATURES','gpu','${PREFERRED_PROVIDER_virtual/gpudriver}-src','',d)}"
 
-# Remove gpudriver sources for ti33x and ti43x family of devices until SGX driver is fixed
+# Remove gpudriver sources for legacy family of devices until SGX driver is fixed
 GRAPHICS_RDEPENDS:remove:ti33x = "${@bb.utils.contains('MACHINE_FEATURES','gpu','${PREFERRED_PROVIDER_virtual/gpudriver}-src','',d)}"
 GRAPHICS_RDEPENDS:remove:ti43x = "${@bb.utils.contains('MACHINE_FEATURES','gpu','${PREFERRED_PROVIDER_virtual/gpudriver}-src','',d)}"
+GRAPHICS_RDEPENDS:remove:am65xx = "${@bb.utils.contains('MACHINE_FEATURES','gpu','${PREFERRED_PROVIDER_virtual/gpudriver}-src','',d)}"
 
 # Task to install crypto sources in SDK"
 CRYPTO_RDEPENDS = "cryptodev-module-src"


### PR DESCRIPTION
Temporarily drop SGX sources for am65xx until following build failures is resolved.

```
nothing provides ti-sgx-ddk-km-src needed by packagegroup-arago-tisdk-sourceipks-sdk-host-1.0-r6.0.am65xx_evm
```