### PR TITLE
recipes-demos: ti-demo: wait for dev-dri-card1 before starting on eglfs

### DIFF
--- a/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
+++ b/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
@@ -51,8 +51,8 @@ CONFIG_FILE:j784s4 = "am69-sk"
 CONFIG_FILE:j722s = "am67-sk"
 
 SERVICE_SUFFIX = ""
-# SERVICE_SUFFIX:am62xx = "-analytics"
-# SERVICE_SUFFIX:am62pxx = "-analytics"
+SERVICE_SUFFIX:am62xx = "-analytics"
+SERVICE_SUFFIX:am62pxx = "-analytics"
 SERVICE_SUFFIX:am62xxsip-evm = "-eglfs"
 
 HW_CODEC = "0"
@@ -100,7 +100,7 @@ do_install:append() {
         install -m 0755 ${WORKDIR}/ti-demo.service ${D}${systemd_system_unitdir}/ti-demo.service
     fi
 
-    if [ "${SERVICE_SUFFIX}" == "-eglfs" ]; then
+    if [ "${SERVICE_SUFFIX}" == "-eglfs" ] || [ "${DISPLAY_CLUSTER_ENABLE}" == "1" ]; then
         install -d ${D}${sysconfdir}/udev/rules.d
         install -m 0644 ${WORKDIR}/dev-dri-card1.rules ${D}${sysconfdir}/udev/rules.d/
     fi

--- a/recipes-demos/ti-apps-launcher/ti-apps-launcher/ti-demo.service
+++ b/recipes-demos/ti-apps-launcher/ti-apps-launcher/ti-demo.service
@@ -4,6 +4,9 @@
 [Unit]
 Description=ti-demo service
 
+Wants=dev-dri-card1.device
+After=dev-dri-card1.device
+
 [Service]
 Type=simple
 EnvironmentFile=/etc/environment


### PR DESCRIPTION
- On eglfs based systems, the ti-demo is starting before the display and gpu cards are enumerated resulting in kernel crashes. So add the udev rule for /dev/dri/card1 in display cluster filesystem and wait for it before starting apps on eglfs.

- Switch to using analytics service for AM62x & AM62P as meta-edgeai is now stable