### PR TITLE
Jailhouse: Update SRCREV for 10.01.08 tag

### DIFF
--- a/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
@@ -1,4 +1,4 @@
-SRCREV:tie-jailhouse = "6301979bc99cd27951ee140df4b29bcfa4823fdd"
+SRCREV:tie-jailhouse = "896df1648441f58a953f837e517e0410d374f3ed"
 
 IPC_DM_FW = "ipc_echo_testb_mcu1_0_release_strip.xer5f"
 

--- a/recipes-kernel/linux/linux-ti-staging-rt_%.bbappend
+++ b/recipes-kernel/linux/linux-ti-staging-rt_%.bbappend
@@ -1,4 +1,4 @@
-SRCREV:tie-jailhouse = "782a2e18a2af099d5c53bc4ba9f59d24a0ce8467"
+SRCREV:tie-jailhouse = "c4cc0a1b3c835d7d77c3ad2a5d1f93526e917dcb"
 
 PR:append = "_tisdk_8"
 

--- a/recipes-kernel/linux/linux-ti-staging_%.bbappend
+++ b/recipes-kernel/linux/linux-ti-staging_%.bbappend
@@ -1,4 +1,4 @@
-SRCREV:tie-jailhouse = "c76373e447c96b32fe08beceef7a499d16eaed96"
+SRCREV:tie-jailhouse = "82e2d1d36703c8ecd9c841e08549306632396f7c"
 
 PR:append = "_tisdk_5"
 

--- a/recipes-ti/jailhouse/jailhouse_git.bbappend
+++ b/recipes-ti/jailhouse/jailhouse_git.bbappend
@@ -4,7 +4,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://jailhouse_root_oob.sh"
 
-SRCREV = "c95e329cef2ef3123e4a5f40511d49640f34495a"
+SRCREV = "42055c4e023f239b3f550940c59fb83024784843"
 
 do_install:append () {
 	sed -i '2i\start_linux_demo() {\' ${D}${JH_DATADIR}/linux-demo.sh


### PR DESCRIPTION
- Update SRCREV for linux and rt linux branch.
- Update SRCREV for uboot branch.
- Update SRCREV for jailhouse repo which fixes jailhouse failure on am62pxx-evm