### PR TITLE
pdm-anomaly-detection: Drop all the references of pdm-anomaly-detection

### DIFF
--- a/conf/distro/include/arago-source-ipk.inc
+++ b/conf/distro/include/arago-source-ipk.inc
@@ -46,9 +46,6 @@ SRCIPK_INSTALL_DIR:pn-arm-benchmarks ?= "example-applications/${PN}-${PV}"
 CREATE_SRCIPK:pn-oprofile-example ?= "1"
 SRCIPK_INSTALL_DIR:pn-oprofile-example ?= "example-applications/${PN}"
 
-CREATE_SRCIPK:pn-pdm-anomaly-detection ?= "1"
-SRCIPK_INSTALL_DIR:pn-pdm-anomaly-detection ?= "example-applications/${PN}-${PV}"
-
 CREATE_SRCIPK:pn-u-boot-ti-staging ?= "1"
 SRCIPK_INSTALL_DIR:pn-u-boot-ti-staging ?= "${@oe.utils.conditional("TI_EXTRAS", "tie-jailhouse", "board-support/u-boot-extras-jailhouse-${PV}${UBOOT_LOCALVERSION}", "board-support/ti-u-boot-${PV}${UBOOT_LOCALVERSION}", d)}"
 SRCIPK_PRESERVE_GIT:pn-u-boot-ti-staging ?= "true"

--- a/recipes-core/packagegroups/packagegroup-arago-tisdk-sourceipks-sdk-host.bb
+++ b/recipes-core/packagegroups/packagegroup-arago-tisdk-sourceipks-sdk-host.bb
@@ -46,7 +46,6 @@ UTILS:append:ti33x = " \
     evse-hmi-src \
     protection-relays-hmi-src \
     oprofile-example-src \
-    ${@bb.utils.contains('MACHINE_FEATURES', 'gpu', 'pdm-anomaly-detection-src', '', d)} \
 "
 
 UTILS:append:ti43x = " \
@@ -54,13 +53,11 @@ UTILS:append:ti43x = " \
     mmwavegesture-hmi-src \
     evse-hmi-src \
     oprofile-example-src \
-    ${@bb.utils.contains('MACHINE_FEATURES', 'gpu', 'pdm-anomaly-detection-src', '', d)} \
 "
 
 UTILS:append:am65xx = " \
     pru-icss-src \
     oprofile-example-src \
-    ${@bb.utils.contains('MACHINE_FEATURES', 'gpu', 'pdm-anomaly-detection-src', '', d)} \
 "
 
 UTILS:append = " \


### PR DESCRIPTION
This QT-5 based recipe is dropped along with meta-arago-demos layer in meta-arago. Hence remove all the references in meta-tisdk. Refer the commit: https://git.ti.com/cgit/arago-project/meta-arago/commit/?h=scarthgap&id=3b605894553664a74e260bb305deab92e67f3983