### PR TITLE
jailhouse: Update SRCREV for 11.00.04 tag

### DIFF
--- a/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
@@ -1,4 +1,4 @@
-SRCREV:tie-jailhouse = "5d20b4ba8d544224f8178cf93535fc660c455d3c"
+SRCREV:tie-jailhouse = "03740dcaec3959431cd59683d795aaaac216972f"
 
 IPC_DM_FW = "ipc_echo_testb_mcu1_0_release_strip.xer5f"
 

--- a/recipes-kernel/linux/linux-ti-staging-rt_%.bbappend
+++ b/recipes-kernel/linux/linux-ti-staging-rt_%.bbappend
@@ -1,4 +1,4 @@
-SRCREV:tie-jailhouse = "a3ce6521b15d7ea3436a40b928f581ef162d449c"
+SRCREV:tie-jailhouse = "e721530500bb7cee961de532df9e8aba6c7db380"
 
 PR:append = "_tisdk_8"
 

--- a/recipes-kernel/linux/linux-ti-staging_%.bbappend
+++ b/recipes-kernel/linux/linux-ti-staging_%.bbappend
@@ -1,4 +1,4 @@
-SRCREV:tie-jailhouse = "9419c5563fb71ff032ef2b406681db1cd3bf667d"
+SRCREV:tie-jailhouse = "e721530500bb7cee961de532df9e8aba6c7db380"
 
 PR:append = "_tisdk_5"
 

--- a/recipes-ti/jailhouse/jailhouse-inmate.bbappend
+++ b/recipes-ti/jailhouse/jailhouse-inmate.bbappend
@@ -1,0 +1,3 @@
+PR:append = "_tisdk_1"
+
+SRCREV = "ef512f9591febed854d8f07ad8c1fa731c2d3c69"

--- a/recipes-ti/jailhouse/jailhouse_git.bbappend
+++ b/recipes-ti/jailhouse/jailhouse_git.bbappend
@@ -4,7 +4,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "file://jailhouse_root_oob.sh"
 
-SRCREV = "42055c4e023f239b3f550940c59fb83024784843"
+SRCREV = "ef512f9591febed854d8f07ad8c1fa731c2d3c69"
 
 do_install:append () {
 	sed -i '2i\start_linux_demo() {\' ${D}${JH_DATADIR}/linux-demo.sh


### PR DESCRIPTION
Update SRCREV for linux and RT-linux build.
Update SRCREV for uboot branch.
Update SRCREV for jailhouse and jailhouse-inmate recipe.