### PR TITLE
recipes-demos: Inherit qt6-qmake conditionally

### DIFF
--- a/recipes-demos/qmltermwidget/qmltermwidget.bb
+++ b/recipes-demos/qmltermwidget/qmltermwidget.bb
@@ -16,6 +16,6 @@ SRC_URI = " \
 "
 S = "${WORKDIR}/git"
 
-inherit qt6-qmake
+inherit ${@bb.utils.contains('BBLAYERS', 'meta-qt6', 'qt6-qmake', '', d)}
 
 FILES:${PN} += "${libdir}"

--- a/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
+++ b/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
@@ -65,7 +65,7 @@ APP_NAME = "${@oe.utils.conditional("DISPLAY_CLUSTER_ENABLE", "1", "ti-demo", "t
 RT_BUILD_VALUE = "${@oe.utils.conditional("ARAGO_RT_ENABLE", "1", "1", "0", d)}"
 QMAKE_PROFILES = "${S}/${APP_NAME}.pro"
 
-inherit qt6-qmake deploy systemd
+inherit ${@bb.utils.contains('BBLAYERS', 'meta-qt6', 'qt6-qmake', '', d)} deploy systemd
 
 SYSTEMD_PACKAGES = "${PN}"
 


### PR DESCRIPTION
meta-qt6 is now implemented as a dynamic layer in meta-arago [1] 
Hence, update the recipes to make the inheritance of qt6-qmake dependent on the presence of meta-qt6 layer in bblayers.conf

This commit resolves build failures observed at parsing stage for platforms where meta-qt6 layer is not included in bblayers.conf

[1]: https://git.ti.com/cgit/arago-project/meta-arago/commit/?h=scarthgap&id=b7eb334b61b874b92c8ab624a19071c74d1e5f9d