### PR TITLE
recipes-multimedia: Add support for default alsastate

### DIFF
--- a/recipes-multimedia/alsa-state/alsa-state.bbappend
+++ b/recipes-multimedia/alsa-state/alsa-state.bbappend
@@ -1,0 +1,22 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI:append = "\
+    file://asound.state \
+"
+CARD_NAME=""
+CARD_NAME:am62xx="AM62xSKEVM"
+CARD_NAME:am62pxx="AM62xSKEVM"
+CARD_NAME:am62axx="AM62AxSKEVM"
+CARD_NAME:am62lxx="AM62LSKEVM"
+
+
+do_install:append() {
+    if [ -n "${CARD_NAME}" ]; then
+	sed -i "s/state.example/state.${CARD_NAME}/"  ${WORKDIR}/asound.state
+	install -d ${D}/var/lib/alsa/
+	install -m 0755 ${WORKDIR}/asound.state ${D}/var/lib/alsa/asound.state
+    fi
+}
+
+PR:append = "_tisdk_1"
+

--- a/recipes-multimedia/alsa-state/alsa-state/asound.state
+++ b/recipes-multimedia/alsa-state/alsa-state/asound.state
@@ -1,0 +1,54 @@
+state.example {
+        control.0 {
+                iface MIXER
+                name 'PGA Capture Volume'
+                value.0 107
+                value.1 107
+                comment {
+                        access 'read write'
+                        type INTEGER
+                        count 2
+                        range '0 - 119'
+                        dbmin 0
+                        dbmax 5950
+                        dbvalue.0 5350
+                        dbvalue.1 5350
+                }
+        }
+        control.2{
+                iface MIXER
+                name 'Left PGA Mixer Mic3R Switch'
+                value true
+                comment {
+                        access 'read write'
+                        type BOOLEAN
+                        count 1
+                }
+        }
+        control.4 {
+                iface MIXER
+                name 'Right PGA Mixer Mic3R Switch'
+                value true
+                comment {
+                        access 'read write'
+                        type BOOLEAN
+                        count 1
+                }
+        }
+        control.5 {
+                iface MIXER
+                name 'PCM Playback Volume'
+                value.0 114
+                value.1 114
+                comment {
+                        access 'read write'
+                        type INTEGER
+                        count 2
+                        range '0 - 127'
+                        dbmin -6350
+                        dbmax 0
+                        dbvalue.0 -2000
+                        dbvalue.1 -2000
+                }
+        }
+}


### PR DESCRIPTION
Add default alsa state for AM62x, AM62P, AM62A & AM62L
 - unmute MICR3R on codec to enable recoridng using mic pin on 3.5mm jack
 - default capture volume & playback volume set to 90%