### PR TITLE
Update ti-apps-launcher

### DIFF
--- a/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
+++ b/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
@@ -10,8 +10,30 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 LICENSE = "TI-TFL"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=5c3a7f5f6886ba6f33ec3d214dc7ab4c"
 
-DEPENDS = "qtbase qtquick3d qtdeclarative qtgraphicaleffects qtmultimedia qtxmlpatterns qmltermwidget"
-RDEPENDS:${PN} = "qtquick3d qtmultimedia bash seva-launcher pulseaudio-service qtdeclarative-qmlplugins qtgraphicaleffects-qmlplugins qmltermwidget"
+DEPENDS = "\
+    qtbase \
+    qtquick3d \
+    qtdeclarative \
+    qtgraphicaleffects \
+    qtmultimedia \
+    qtxmlpatterns \
+    qmltermwidget \
+"
+
+RDEPENDS:${PN} = "\
+    qtquick3d \
+    qtmultimedia \
+    bash \
+    seva-launcher \
+    pulseaudio-service \
+    qtdeclarative-qmlplugins \
+    qtgraphicaleffects-qmlplugins \
+    qmltermwidget \
+    qtquickcontrols-qmlplugins \
+    qtquickcontrols2-qmlplugins \
+    qtwayland-qmlplugins \
+"
+
 RDEPENDS:${PN}:remove:am62xxsip-evm = "seva-launcher"
 RDEPENDS:${PN}:append:am62xx = " powervr-graphics"
 RDEPENDS:${PN}:append:am62pxx = " powervr-graphics"

--- a/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
+++ b/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
@@ -8,7 +8,7 @@ COMPATIBLE_MACHINE = "am62xx|am62pxx|j721s2|j784s4|j722s"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 LICENSE = "TI-TFL"
-LIC_FILES_CHKSUM = "file://${WORKDIR}/git/LICENSE;md5=5c3a7f5f6886ba6f33ec3d214dc7ab4c"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=5c3a7f5f6886ba6f33ec3d214dc7ab4c"
 
 DEPENDS = "qtbase qtquick3d qtdeclarative qtgraphicaleffects qtmultimedia qtxmlpatterns qmltermwidget"
 RDEPENDS:${PN} = "qtquick3d qtmultimedia bash seva-launcher pulseaudio-service qtdeclarative-qmlplugins qtgraphicaleffects-qmlplugins qmltermwidget"

--- a/recipes-demos/ti-apps-launcher/ti-apps-launcher/ti-demo.service
+++ b/recipes-demos/ti-apps-launcher/ti-apps-launcher/ti-demo.service
@@ -13,7 +13,7 @@ EnvironmentFile=/etc/environment
 Environment=QT_QPA_PLATFORM=eglfs
 Environment=QT_QPA_EGLFS_KMS_CONFIG=/etc/eglfs.conf
 ExecStartPre=/bin/sh -c 'for i in $(find /sys/devices/platform -name "card?"); do export D=${i:0-1}; if [[ "$i" == *"dss"* ]]; then echo -e "{\n\t\x5c\x22device\x5c\x22: \x5c\x22/dev/dri/card${i:0-1}\x5c\x22,\n\t\x5c\x22hwcursor\x5c\x22: false\n}\n" > /etc/eglfs.conf ; fi; done'
-ExecStart=/usr/bin/ti-demo -platform eglfs
+ExecStart=qmlscene -platform eglfs --fullscreen /opt/ti-demo/auto_cluster.qml
 
 # The user to run ti-demo as.
 User=root


### PR DESCRIPTION
Update to the latest. Changes include switching to CMake for build, removing now unneeded qmake file changes, and using qmlscene for the auto cluster instead of making a dedicated program for it.