### PR TITLE
recipes-bsp: Display Cluster: Pass BINMAN_ALLOW_MISSING flag

### DIFF
--- a/meta-ti-foundational/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
+++ b/meta-ti-foundational/recipes-bsp/u-boot/u-boot-ti-staging_%.bbappend
@@ -9,7 +9,7 @@ DM_FIRMWARE:am62pxx = "${@oe.utils.conditional("DISPLAY_CLUSTER_ENABLE", "1", "$
 
 TI_DM="${STAGING_DIR_HOST}${nonarch_base_libdir}/firmware/ti-dm/${PLAT_SFX}/${DM_FIRMWARE}"
 
-EXTRA_OEMAKE += "TI_DM=${TI_DM}"
+EXTRA_OEMAKE += "TI_DM=${TI_DM} ${@oe.utils.conditional("DISPLAY_CLUSTER_ENABLE", "1", "BINMAN_ALLOW_MISSING=1", "", d)}"
 
 PR:append = "_tisdk_5"
 


### PR DESCRIPTION
- For AM62P Display Cluster, we need to set the BINMAN_ALLOW_MISSING flag to avoid including optional external blobs for ti-dm. By enabling this flag during the display cluster build, dss_display_share.wkup-r5f0_0.release.strip.out blob is used in ti-dm skipping the potential issues caused by the optional ipc_echo_testb_mcu1_0_release_strip.xer5f blob, which is normally used in other builds.