### PR TITLE
meta-ti-ml: Add new sublayer for EdgeAI

### DIFF
--- a/meta-ti-ml/README
+++ b/meta-ti-ml/README
@@ -1,0 +1,41 @@
+meta-ti-ml layer serves as a Machine Learning Layer for TI SDK products.
+
+This layer works with the latest Yocto Project release (currently 5.0+) and tracks
+the stable/maintenance branches (currently "scarthgap") of the corresponding layers:
+
+URI: git://git.openembedded.org/openembedded-core
+branch: scarthgap
+revision: HEAD
+layers: meta
+
+URI: git://git.yoctoproject.org/meta-ti
+branch: scarthgap
+revision: HEAD
+layers: meta-ti-bsp, meta-ti-extras
+
+URI: git://git.yoctoproject.org/meta-arm
+branch: scarthgap
+revision: HEAD
+layers: meta-arm, meta-arm-toolchain
+
+URI: git://git.openembedded.org/meta-openembedded
+branch: scarthgap
+revision: HEAD
+layers: meta-oe, meta-networking, meta-python
+
+URI: git://git.yoctoproject.org/meta-arago
+branch: scarthgap
+revision: HEAD
+layers: meta-arago-distro, meta-arago-extras, meta-arago-test
+
+URI: https://github.com/TexasInstruments/meta-tisdk
+branch: scarthgap
+revision: HEAD
+layers: meta-ti-foundational
+
+Please submit any patches against the meta-tisdk layer by using the GitHub pull-request feature.
+You are encouraged to fork the mirror on GitHub https://github.com/TexasInstruments/meta-tisdk
+to share your patches.
+
+Layer Maintainers:
+Chirag Shilwant <c-shilwant@ti.com>

--- a/meta-ti-ml/conf/layer.conf
+++ b/meta-ti-ml/conf/layer.conf
@@ -1,0 +1,23 @@
+# We have a conf and classes directory, append to BBPATH
+BBPATH .= ":${LAYERDIR}"
+
+# We have a recipes directory, add to BBFILES
+BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
+
+BBFILE_COLLECTIONS += "meta-ti-ml"
+BBFILE_PATTERN_meta-ti-ml := "^${LAYERDIR}/"
+
+# We keep the priority higher than all others
+BBFILE_PRIORITY_meta-ti-ml = "12"
+
+LAYERDEPENDS_meta-ti-ml = " \
+    core \
+    meta-ti-bsp \
+    meta-ti-extras \
+    meta-arago-distro \
+    meta-arago-extras \
+    meta-arago-test \
+    meta-ti-foundational \
+"
+
+LAYERSERIES_COMPAT_meta-ti-ml = "scarthgap"

--- a/meta-ti-ml/recipes-core/images/tisdk-default-image.bbappend
+++ b/meta-ti-ml/recipes-core/images/tisdk-default-image.bbappend
@@ -1,0 +1,11 @@
+PR:append = "_tisdk_ml_0"
+
+IMAGE_INSTALL:append = " \
+    tensorflow-lite \
+    onnx \
+    onnxruntime \
+    armnn \
+    arm-compute-library \
+    nnstreamer \
+    nnshark \
+"


### PR DESCRIPTION
```
commit 31679bfaefd2f7ee1601d649fce4294c939fd7d8
Author: Chirag Shilwant <c-shilwant@ti.com>
Date:   Mon Mar 17 19:11:12 2025 +0530

    meta-ti-ml: recipes-core: Enable ARM only AI stack
    
    * Enable ARM only AI stack in tisdk-default-image for
    meta-tisdk:meta-ti-ml builds by default
    
    * The recipes for entire ARM only stack is present in
    meta-arago-extras [0]
    
    [0]: https://git.yoctoproject.org/meta-arago/log/meta-arago-extras?h=11.00.07
    
    Signed-off-by: Chirag Shilwant <c-shilwant@ti.com>
```

```
commit 1cd2c7356e3507a1329429ae1b16f83204d490be
Author: Chirag Shilwant <c-shilwant@ti.com>
Date:   Mon Mar 17 19:06:38 2025 +0530

    meta-ti-ml: Add new sublayer for EdgeAI
    
    * The meta-ti-ml sublayer serves as a Machine Learning Layer
    for TI SDK products
    
    * Add layer.conf & basic README file for meta-ti-ml
    
    Signed-off-by: Chirag Shilwant <c-shilwant@ti.com>
```