### PR TITLE
recipes-core: packagegroups: Drop references of purged components

### DIFF
--- a/meta-ti-foundational/recipes-core/packagegroups/packagegroup-arago-tisdk-sourceipks-sdk-host.bb
+++ b/meta-ti-foundational/recipes-core/packagegroups/packagegroup-arago-tisdk-sourceipks-sdk-host.bb
@@ -42,16 +42,11 @@ UTILS:append:am335x-evm = " pru-adc-src"
 UTILS:append:ti33x = " \
     omapconf-src \
     pru-icss-src \
-    mmwavegesture-hmi-src \
-    evse-hmi-src \
-    protection-relays-hmi-src \
     oprofile-example-src \
 "
 
 UTILS:append:ti43x = " \
     pru-icss-src \
-    mmwavegesture-hmi-src \
-    evse-hmi-src \
     oprofile-example-src \
 "
 


### PR DESCRIPTION
* evse-hmi, protection-relays-hmi & mmwavegesture-hmi were a part of meta-arago-demos which no longer exists [0]. Hence, drop references of these components under meta-tisdk.

* This resolves following build failures observed with AM335x & AM437x with meta-tisdk:scarthgap:HEAD,

```

ERROR: Nothing RPROVIDES 'evse-hmi-src' (but packagegroup-arago-tisdk-sourceipks-sdk-host.bb RDEPENDS on or otherwise requires it)
Missing or unbuildable dependency chain was: ['evse-hmi-src']

ERROR: Nothing RPROVIDES 'protection-relays-hmi-src' (but packagegroup-arago-tisdk-sourceipks-sdk-host.bb RDEPENDS on or otherwise requires it)
Missing or unbuildable dependency chain was: ['protection-relays-hmi-src']

ERROR: Nothing RPROVIDES 'mmwavegesture-hmi-src' (but packagegroup-arago-tisdk-sourceipks-sdk-host.bb RDEPENDS on or otherwise requires it)
Missing or unbuildable dependency chain was: ['mmwavegesture-hmi-src']

```

[0]: https://git.yoctoproject.org/meta-arago/commit/?h=scarthgap&id=3b605894553664a74e260bb305deab92e67f3983