### PR TITLE
meta-ti-ml: Add Analytics demo data recipe

### DIFF
--- a/meta-ti-ml/recipes-core/images/tisdk-default-image.bbappend
+++ b/meta-ti-ml/recipes-core/images/tisdk-default-image.bbappend
@@ -8,4 +8,5 @@ IMAGE_INSTALL:append = " \
     arm-compute-library \
     nnstreamer \
     nnshark \
+    analytics-demo-data \
 "

--- a/meta-ti-ml/recipes-demos/analytics-demo-data/analytics-demo-data.bb
+++ b/meta-ti-ml/recipes-demos/analytics-demo-data/analytics-demo-data.bb
@@ -1,0 +1,22 @@
+DESCRIPTION = "Model test data for ARM Analytics demos"
+HOMEPAGE = "https://github.com/glneo/oob-demo-assets"
+LICENSE = "TI-TFL"
+LIC_FILES_CHKSUM = "file://${COREBASE}/../meta-ti/meta-ti-bsp/licenses/TI-TFL;md5=a1b59cb7ba626b9dbbcbf00f3fbc438a"
+
+SRC_URI = "git://github.com/glneo/oob-demo-assets.git;protocol=https;branch=master"
+SRCREV = "3deadefecc49877c7f6c9d59854f801fa3fc43e1"
+
+S = "${WORKDIR}/git"
+
+do_install() {
+	CP_ARGS="-Prf --preserve=mode,timestamps --no-preserve=ownership"
+
+	install -d ${D}${datadir}/oob-demo-assets
+	cp ${CP_ARGS} ${S}/* ${D}${datadir}/oob-demo-assets
+}
+
+# No configure nor build steps
+do_configure[noexec] = "1"
+do_compile[noexec] = "1"
+
+FILES:${PN} = "${datadir}/oob-demo-assets"


### PR DESCRIPTION
Add sample data for analytics demos including labels, models, and test videos.