### PR TITLE
meta-ti-foundational: Update Jailhouse SRCREV for 11.00.08

### DIFF
--- a/meta-ti-foundational/recipes-bsp/u-boot/u-boot-ti-staging_2025.01.bbappend
+++ b/meta-ti-foundational/recipes-bsp/u-boot/u-boot-ti-staging_2025.01.bbappend
@@ -1,4 +1,4 @@
-SRCREV:tie-jailhouse = "c8badfb165815c648052309418987f302e48aeef"
+SRCREV:tie-jailhouse = "e7eeb7586fab6cd9e91d49d5b5ad68287d9bc8b6"
 
 IPC_DM_FW = "ipc_echo_testb_mcu1_0_release_strip.xer5f"
 

--- a/meta-ti-foundational/recipes-kernel/linux/linux-ti-staging-rt_6.12.bbappend
+++ b/meta-ti-foundational/recipes-kernel/linux/linux-ti-staging-rt_6.12.bbappend
@@ -1,4 +1,4 @@
-SRCREV:tie-jailhouse = "506f0328c87365e9dce525956c42f8c393129db3"
+SRCREV:tie-jailhouse = "0960c2a8ba6ced8f8134cca3312c2854e704c072"
 
 PR:append = "_tisdk_8"
 

--- a/meta-ti-foundational/recipes-kernel/linux/linux-ti-staging_6.12.bbappend
+++ b/meta-ti-foundational/recipes-kernel/linux/linux-ti-staging_6.12.bbappend
@@ -1,4 +1,4 @@
-SRCREV:tie-jailhouse = "506f0328c87365e9dce525956c42f8c393129db3"
+SRCREV:tie-jailhouse = "0960c2a8ba6ced8f8134cca3312c2854e704c072"
 
 PR:append = "_tisdk_5"
 


### PR DESCRIPTION
Update SRCREV for linux and RT-linux build.
Update SRCREV for uboot branch.