### PR TITLE
meta-ti-foundational: conf: Avoid hard dependency on meta-qt6

### DIFF
--- a/meta-ti-foundational/conf/layer.conf
+++ b/meta-ti-foundational/conf/layer.conf
@@ -14,13 +14,16 @@ LAYERDEPENDS_meta-ti-foundational = " \
     core \
     meta-ti-bsp \
     meta-ti-extras \
-    qt6-layer \
     meta-arago-distro \
     meta-arago-extras \
     meta-arago-test \
 "
 
 LAYERSERIES_COMPAT_meta-ti-foundational = "scarthgap"
+
+LAYERRECOMMENDS_meta-ti-foundational = " \
+    qt6-layer \
+"
 
 # Generate -src ipks packages for sources to be added to the SDK installer
 require conf/distro/include/arago-source-ipk.inc


### PR DESCRIPTION
* QT6 is implemented as a dynamic layer in meta-arago-extras [0] which makes it possible to not ship QT as a standard offering for SDKs of low end microprocessors [1].

* Hence, to leverage the dynamic layer implementation [0] & avoid the inclusion of meta-qt6 in bblayers.conf, switch to a less aggressive variable (i.e. LAYERRECOMMENDS) [2] to list the layers.

[0]: https://git.yoctoproject.org/meta-arago/commit/?h=scarthgap&id=b7eb334b61b874b92c8ab624a19071c74d1e5f9d

[1]: https://git.ti.com/cgit/arago-project/oe-layersetup/commit/?id=1df35706074fbd421a553935d1f3562ba486c8cb

[2]: https://docs.yoctoproject.org/ref-manual/variables.html#term-LAYERRECOMMENDS