### PR TITLE
Package HSM firmwares in Prebuilt-images directory

### DIFF
--- a/meta-ti-foundational/recipes-core/images/tisdk-core-bundle.bbappend
+++ b/meta-ti-foundational/recipes-core/images/tisdk-core-bundle.bbappend
@@ -77,6 +77,13 @@ tisdk_image_build:append() {
         cp -r ${DEPLOY_DIR_IMAGE}/ti-dm ${PREBUILT_DIR}/
     fi
 
+    # Add ti-hsm needed by binman builds for u-boot
+    if [ -d "${DEPLOY_DIR_IMAGE}/ti-hsm" ]
+    then
+        mkdir -p ${PREBUILT_DIR}/ti-hsm/
+        cp ${DEPLOY_DIR_IMAGE}/ti-hsm/* ${PREBUILT_DIR}/ti-hsm/
+    fi
+
     # Copy all the boot partition files (for all soc types: gp/hs/hs-fs)
     for f in ${BOOT_PART}
     do


### PR DESCRIPTION
meta-ti-foundational: recipes-core: tisdk-core-bundle: Pick HSM firmware

The HSM firmwares are exported by the meta-ti layer in the deploy directory. Copy those HSM firmwares into the PREBUILT_DIR needed for U-Boot builds.