### PR TITLE
meta-ti-ml: nnstreamer: Fix issue with switching between ML demos

### DIFF
--- a/meta-ti-ml/recipes-multimedia/nnstreamer/nnstreamer/0001-decoder-Do-not-clear-properties_table-in-BoundingBox.patch
+++ b/meta-ti-ml/recipes-multimedia/nnstreamer/nnstreamer/0001-decoder-Do-not-clear-properties_table-in-BoundingBox.patch
@@ -1,0 +1,40 @@
+From 4e26268e4d36f50244ed964c54f88a02db7ff420 Mon Sep 17 00:00:00 2001
+From: Andrew Davis <afd@ti.com>
+Date: Fri, 28 Mar 2025 10:46:51 -0500
+Subject: [PATCH] [decoder] Do not clear properties_table in BoundingBox
+ destructor
+
+The properties_table contains the list of properties for loaded
+sub-modules. The properties are only added on initial module load
+which happens once, this is why the table is a static singleton
+not tied to the lifecycle of any one BoundingBox instance.
+
+The issue is this table is cleared in the BoundingBox destructor,
+which means after any BoundingBox instance is removed, no new
+instances will be able to find any sub-module properties.
+
+Fix this by not clearing the properties_table in the destructor.
+
+Upstream-Status: Pending
+
+Signed-off-by: Andrew Davis <afd@ti.com>
+---
+ ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
+index e1fdebaf..7494703c 100644
+--- a/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
++++ b/ext/nnstreamer/tensor_decoder/tensordec-boundingbox.cc
+@@ -429,11 +429,6 @@ BoundingBox::~BoundingBox ()
+ 
+   g_array_free (centroids, TRUE);
+   g_array_free (distanceArray, TRUE);
+-
+-  G_LOCK (box_properties_table);
+-  g_hash_table_destroy (properties_table);
+-  properties_table = nullptr;
+-  G_UNLOCK (box_properties_table);
+ }
+ 
+ /**

--- a/meta-ti-ml/recipes-multimedia/nnstreamer/nnstreamer_2.4.0.bbappend
+++ b/meta-ti-ml/recipes-multimedia/nnstreamer/nnstreamer_2.4.0.bbappend
@@ -1,0 +1,4 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI += "file://0001-decoder-Do-not-clear-properties_table-in-BoundingBox.patch"
+


### PR DESCRIPTION
Internal issue with NNStreamer caused a crash when switching demos in ti-apps-launcher. Carry patch while fix is being upstreamed.