### PR TITLE
meta-ti-foundational: ti-apps-launcher: Fix service file

### DIFF
--- a/meta-ti-foundational/recipes-bsp/powervr-drivers/ti-img-rogue-driver_24.2.6643903.bbappend
+++ b/meta-ti-foundational/recipes-bsp/powervr-drivers/ti-img-rogue-driver_24.2.6643903.bbappend
@@ -1,0 +1,3 @@
+PR:append = "_tisdk_0"
+
+SRCREV = "8eaff654a8871118c08cfafe53795f57e3b6b396"

--- a/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher/ti-apps-launcher.service
+++ b/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher/ti-apps-launcher.service
@@ -3,30 +3,24 @@
 
 [Unit]
 Description=ti-apps-launcher service
-
-# Make sure we are started after logins are permitted.
 Requires=emptty.service docker.socket
-After=docker.service
+After=systemd-user-sessions.service docker.service emptty.service
 
 [Service]
-# Requires systemd-notify.so Weston plugin.
 Type=simple
 Environment=XDG_RUNTIME_DIR=/run/user/1000
 Environment=QT_QPA_PLATFORM=wayland
 Environment=WAYLAND_DISPLAY=wayland-1
+Environment=QML_DISABLE_DISK_CACHE=1
+Environment=QT_DISABLE_SHADER_DISK_CACHE=1
 EnvironmentFile=/etc/environment
-ExecStartPre=/bin/sh -c 'for i in $(seq 1 60); do [ -S /run/user/1000/wayland-1 ] && exit 0 || sleep 1; done; exit 1'
+ExecStartPre=/bin/sh -c 'while [ ! -S /run/user/1000/wayland-1 ]; do sleep 1; done'
 ExecStart=/bin/sh -c '/usr/bin/ti-apps-launcher'
 
-# The user to run Weston as.
+Restart=on-failure
+
 User=root
 Group=root
 
-# Fail to start if not controlling the tty.
-StandardOutput=journal
-StandardError=journal
-
 [Install]
-# Note: If you only want weston to start on-demand, remove this line with a
-# service drop file
 WantedBy=graphical.target multi-user.target


### PR DESCRIPTION
[meta-ti-foundational: ti-apps-launcher: Fix systemd service file](https://github.com/TexasInstruments/meta-tisdk/pull/76/commits/52634920773000273cf8758040f05475aa510237)
* The ti-apps-launcher systemd service file doesn't wait
entirely until weston launches. This results in a unexpected
behavior where we see video corruption in ti-apps-launcher

* Hence, update the service file to wait infinitely until /run/user/1000/wayland-1
is created & add a Requires dependency on emptty.

* While at it, also ensure that ti-apps-launcher re-starts on failure.

* Fixes commit https://github.com/TexasInstruments/meta-tisdk/commit/694a3b55ff2384eff12c1f45ee8de3bfcfc58c46

<hr>

[meta-ti-foundational: powervr-drivers: Add ti-img-rogue-driver bbappend](https://github.com/TexasInstruments/meta-tisdk/pull/76/commits/e7a4573d75b5cdcf56ae4276df51e2ceea61e9cb)
* There is a patch on meta-ti:scarthgap which bumps up the SRCREV
of ti-img-rogue-driver_24.2.6643903 recipe to address the kernel
fault in pvr_show_fdinfo associated with fdinfo/lsof [1]

* Since the fix is not part of 11.00.09 tag [2], carry it as a bbappend
in meta-tisdk for SDK 11.0 & revert this commit once meta-ti-bsp promotes
the patch to scarthgap

[1]: https://git.ti.com/cgit/arago-project/meta-ti/commit/?h=scarthgap-next&id=8e697585943f094544eded954c98d8473f7ee1e8

[2]: https://git.ti.com/cgit/arago-project/meta-ti/log/?h=11.00.09

Signed-off-by: Chirag Shilwant <c-shilwant@ti.com>
