### PR TITLE
recipes-demos: Updates on ti-lvgl-demo & qmltermwidget

### DIFF
--- a/meta-ti-foundational/recipes-demos/qmltermwidget/qmltermwidget.bb
+++ b/meta-ti-foundational/recipes-demos/qmltermwidget/qmltermwidget.bb
@@ -16,6 +16,6 @@ SRC_URI = " \
 "
 S = "${WORKDIR}/git"
 
-inherit qt6-qmake
+inherit ${@bb.utils.contains('BBLAYERS', 'meta-qt6', 'qt6-qmake', '', d)}
 
 FILES:${PN} += "${libdir}"

--- a/meta-ti-foundational/recipes-demos/ti-lvgl-demo/ti-lvgl-demo.bb
+++ b/meta-ti-foundational/recipes-demos/ti-lvgl-demo/ti-lvgl-demo.bb
@@ -9,14 +9,14 @@ SRC_URI = "gitsm://github.com/texasinstruments/ti-lvgl-demo.git;branch=master;pr
 S = "${WORKDIR}/git/lv_port_linux"
 B = "${S}/build-arm64"
 
-SRCREV = "a1cec6469551d8ec6c1c0d2d5041c0c5432d9e3b"
+SRCREV = "f9ecfee218b3f74fd5fb43de57da24b643f99217"
 
 inherit systemd
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE:${PN} = "${PN}.service"
 
 DEPENDS += "cmake mosquitto alsa-lib alsa-utils alsa-tools libdrm libsdl2 libsdl2-image curl wayland-protocols curl ca-certificates"
-RDEPENDS:${PN} += "cmake mosquitto alsa-lib alsa-utils alsa-tools libdrm libsdl2 libsdl2-image curl wayland-protocols curl ca-certificates"
+RDEPENDS:${PN} += "cmake mosquitto alsa-lib alsa-utils alsa-tools libdrm libsdl2 libsdl2-image curl wayland-protocols curl ca-certificates tensorflow-lite nnstreamer analytics-demo-data"
 
 inherit cmake
 OECMAKE_SOURCEPATH = "${S}"


### PR DESCRIPTION
commit c9196bbdbc1095b4f717416252f9ab1a4adafd64 
Author: Chirag Shilwant <c-shilwant@ti.com>
Date:   Thu Apr 10 18:01:30 2025 +0530

    recipes-demos: Inherit qt6-qmake conditionally
    
    * meta-qt6 is now implemented as a dynamic layer in meta-arago [1]
    Hence, update the recipes to make the inheritance of qt6-qmake
    dependent on the presence of meta-qt6 layer in bblayers.conf
    
    * This commit resolves build failures observed at parsing stage
    for platforms where meta-qt6 layer is not included in bblayers.conf
    
    * Fixes c34c80e46db16add97cd45243e50db949c6f9cdf
    
    [1]: https://git.ti.com/cgit/arago-project/meta-arago/commit/?h=scarthgap&id=b7eb334b61b874b92c8ab624a19071c74d1e5f9d
    
    Signed-off-by: Chirag Shilwant <c-shilwant@ti.com>

<hr>

commit c548159f306f673b5842b4c4ad1e67656e409931
Author: Chirag Shilwant <c-shilwant@ti.com>
Date:   Thu Apr 10 17:40:50 2025 +0530

    meta-ti-foundational: ti-lvgl-demo: Update SRCREV and add new RDEPENDS
    
    * Update SRCREV to include the new EdgeAI application demonstrating
    Audio classification [0]
    
    * Additionally, add runtime dependencies on tensorflow-lite, nnstreamer
    and analytics-demo-data which are required for running the EdgeAI application.
    
    [0]: https://github.com/TexasInstruments/lvgl/pull/5
    
    Signed-off-by: Chirag Shilwant <c-shilwant@ti.com>
