### PR TITLE
meta-ti-foundational: ti-apps-launcher: Fix RDEPENDS

### DIFF
--- a/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
+++ b/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
@@ -49,6 +49,9 @@ RDEPENDS:${PN} = "\
     analytics-demo-data \
 "
 
+RDEPENDS:${PN}:remove:j721s2 = "tensorflow-lite onnx onnxruntime nnstreamer analytics-demo-data"
+RDEPENDS:${PN}:remove:j784s4 = "tensorflow-lite onnx onnxruntime nnstreamer analytics-demo-data"
+RDEPENDS:${PN}:remove:j722s = "tensorflow-lite onnx onnxruntime nnstreamer analytics-demo-data"
 RDEPENDS:${PN}:remove:am62xxsip-evm = "seva-launcher"
 RDEPENDS:${PN}:append:am62xx = " powervr-graphics"
 RDEPENDS:${PN}:append:am62pxx = " powervr-graphics"


### PR DESCRIPTION
am6[789]-sk devices do not support meta-ti-ml layer. Remove these packages from RDEPENDS to fix builds for these devices without the meta-ti-ml sublayer