### PR TITLE
gstreamer1.0-plugins-good: Add qt6 packageconfig conditionally

### DIFF
--- a/meta-ti-foundational/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.22.%.bbappend
+++ b/meta-ti-foundational/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.22.%.bbappend
@@ -1,6 +1,7 @@
-PR:append = ".arago0"
+PR:append = ".tisdk0"
 
-PACKAGECONFIG:append = " qt6"
+# Enable qt6 packageconfig if meta-qt6 layer is in use
+PACKAGECONFIG:append = " ${@bb.utils.contains('BBLAYERS', 'meta-qt6', 'qt6', '', d)}"
 
 QT6WAYLANDDEPENDS = "${@bb.utils.contains("DISTRO_FEATURES", "wayland", "qtwayland", "", d)}"
 


### PR DESCRIPTION
* meta-qt6 is now implemented as a dynamic layer in meta-arago [1] Hence, update the recipes to use the qt6 packageconfig options dependent on the presence of meta-qt6 layer in bblayers.conf
* This commit resolves build failures observed at parsing stage for platforms where meta-qt6 layer is not included in bblayers.conf
* While at it, update PR append suffix to .tisdk to differentiate from .arago (bbappend in meta-arago-extras)

[1]:
https://git.ti.com/cgit/arago-project/meta-arago/commit/?h=scarthgap&id=b7eb334b61b874b92c8ab624a19071c74d1e5f9d