### PR TITLE
meta-ti-foundational: Fix AM62A build issues & Drop ti-img-rogue-driver bbappend  

### DIFF
--- a/meta-ti-foundational/recipes-bsp/powervr-drivers/ti-img-rogue-driver_24.2.6643903.bbappend
+++ b/meta-ti-foundational/recipes-bsp/powervr-drivers/ti-img-rogue-driver_24.2.6643903.bbappend
@@ -1,3 +1,0 @@
-PR:append = "_tisdk_0"
-
-SRCREV = "8eaff654a8871118c08cfafe53795f57e3b6b396"

--- a/meta-ti-foundational/recipes-core/images/tisdk-core-bundle.bbappend
+++ b/meta-ti-foundational/recipes-core/images/tisdk-core-bundle.bbappend
@@ -58,6 +58,7 @@ SYSFW_PREFIX:am64xx = "sci"
 SYSFW_PREFIX:am65xx = "sci"
 SYSFW_PREFIX:am62xx = "fs*"
 SYSFW_PREFIX:am62pxx = "fs*"
+SYSFW_PREFIX:am62axx = "fs*"
 
 SYSFW_BINARY = "ti-${SYSFW_PREFIX}-firmware-${SYSFW_SOC}*.bin"
 


### PR DESCRIPTION
meta-ti-foundational: powervr-drivers: Drop ti-img-rogue-driver bbappend

* Drop the bbappend file as the fix is now part of meta-ti:scarthgap
under 11.00.10 tag [0][1]

* This reverts commit https://github.com/TexasInstruments/meta-tisdk/commit/2f497ac1090c5b256878d803b96901d73a285840

[0]: https://git.ti.com/cgit/arago-project/meta-ti/log/?h=11.00.10

[1]: https://git.ti.com/cgit/arago-project/meta-ti/commit/?h=11.00.10&id=8e697585943f094544eded954c98d8473f7ee1e8

Signed-off-by: Chirag Shilwant <c-shilwant@ti.com>

<hr>

recipes-core: tisdk-core-bundle: Add SYSFW_PREFIX override for AM62A

* For am62axx, set SYSFW_PREFIX as fs* which ensures that ti-fs-stub*
firmwares are also deployed under board-support/prebuilt-images of
tisdk-core-bundle

* This fixes build errors observed while building U-Boot 2025.01 using
AM62A EdgeAI SDK

Signed-off-by: Chirag Shilwant <c-shilwant@ti.com>
