### PR TITLE
meta-ti-foundational: recipes-multimedia: Add recipes for building ti gstreamer plugins

### DIFF
--- a/meta-ti-foundational/recipes-core/images/tisdk-default-image.bbappend
+++ b/meta-ti-foundational/recipes-core/images/tisdk-default-image.bbappend
@@ -6,3 +6,5 @@ IMAGE_INSTALL:append = " \
 "
 
 IMAGE_INSTALL:append:am62lxx = " mosquitto libmosquitto1 libmosquittopp1 mosquitto-clients mosquitto-dev"
+IMAGE_INSTALL:append:am62xx = " ti-gst-plugins-source ti-gst-plugins-dev ti-gst-utils "
+IMAGE_INSTALL:append:am62pxx = " ti-gst-plugins-source ti-gst-plugins-dev ti-gst-utils "

--- a/meta-ti-foundational/recipes-multimedia/gst-plugins-ti/ti-gst-plugins.bb
+++ b/meta-ti-foundational/recipes-multimedia/gst-plugins-ti/ti-gst-plugins.bb
@@ -1,0 +1,44 @@
+SUMMARY = "Custom arm-only GStreamer plugins for TI devices"
+DESCRIPTION = "TI GST arm-only plugins which internally uses Arm NEON optimized kernels on TI Sitara devices"
+HOMEPAGE = "https://github.com/TexasInstruments/edgeai-gst-plugins"
+
+LICENSE = "TI-TFL"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1f7721ee7d288457c5a70d0c8ff44b87"
+
+PV = "1.0.0"
+BRANCH = "main"
+SRC_URI = "git://github.com/TexasInstruments/edgeai-gst-plugins.git;branch=${BRANCH};protocol=https"
+SRCREV = "39577530481ba0efe5eb0e20becb6442d84d29ac"
+
+PLAT_SOC = ""
+PLAT_SOC:am62xx = "am62x"
+PLAT_SOC:am62pxx = "am62p"
+
+S = "${WORKDIR}/git"
+
+DEPENDS = "gstreamer1.0-plugins-base ti-gst-utils"
+RDEPENDS:${PN}-source = "bash meson ninja"
+
+COMPATIBLE_MACHINE = "am62xx|am62pxx"
+
+export SOC = "${PLAT_SOC}"
+
+PACKAGES += "${PN}-source"
+FILES:${PN}-source += "/opt/"
+FILES:${PN} += "${libdir}/gstreamer-1.0/*.so"
+
+EXTRA_OEMESON = "--prefix=/usr -Dpkg_config_path=${S}/pkgconfig -Ddl-plugins=disabled -Denable-tidl=disabled"
+
+inherit meson pkgconfig
+
+do_install:append() {
+    CP_ARGS="-Prf --preserve=mode,timestamps --no-preserve=ownership"
+
+    mkdir -p ${D}/opt/edgeai-gst-plugins
+    cp ${CP_ARGS} ${S}/* ${D}/opt/edgeai-gst-plugins
+}
+
+INSANE_SKIP:${PN}-source += "dev-deps"
+INSANE_SKIP:${PN} += "rpaths"
+
+PR:append = "tisdk_0"

--- a/meta-ti-foundational/recipes-multimedia/gst-plugins-ti/ti-gst-utils.bb
+++ b/meta-ti-foundational/recipes-multimedia/gst-plugins-ti/ti-gst-utils.bb
@@ -1,0 +1,40 @@
+SUMMARY = "TI GST Utils"
+DESCRIPTION = "TI GST Utils implements ARM neon optimized utility functions and also NV12 post process utility functions required for implementing TI GST arm-only plugins "
+HOMEPAGE = "https://git.ti.com/cgit/edgeai/edgeai-apps-utils"
+
+LICENSE = "TI-TFL"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1f7721ee7d288457c5a70d0c8ff44b87"
+
+PV = "1.0.0"
+BRANCH = "main"
+SRC_URI = "git://git.ti.com/git/edgeai/edgeai-apps-utils.git;protocol=https;branch=${BRANCH}"
+SRCREV = "5a5a694ae02f0d2e4e39028b847e1c777c465cbf"
+
+PLAT_SOC = ""
+PLAT_SOC:am62xx = "am62x"
+PLAT_SOC:am62pxx = "am62p"
+
+S = "${WORKDIR}/git"
+
+RDEPENDS:${PN}-source += "python3-core cmake"
+
+COMPATIBLE_MACHINE = "am62xx|am62pxx"
+
+export SOC = "${PLAT_SOC}"
+
+EXTRA_OECMAKE = "-DTARGET_FS=${WORKDIR}/recipe-sysroot -DCMAKE_SKIP_RPATH=TRUE -DCMAKE_OUTPUT_DIR=${WORKDIR}/out"
+
+PACKAGES += "${PN}-source"
+FILES:${PN}-source += "/opt/"
+
+inherit cmake
+
+do_install:append() {
+    CP_ARGS="-Prf --preserve=mode,timestamps --no-preserve=ownership"
+
+    mkdir -p ${D}/opt/edgeai-apps-utils
+    cp ${CP_ARGS} ${S}/* ${D}/opt/edgeai-apps-utils
+    cd ${D}/opt/edgeai-apps-utils
+}
+
+PR:append = "tisdk_0"


### PR DESCRIPTION
* For AM62X and AM62P along with jacinto devices TI Gstreamer Plugins were implemented in meta-edgeai layer. Since, the meta-edgeai layer is now not included for default image, implement this in meta-tisdk layer.

* This adds the support for ticolorconvert, timosaic, tiperfoverlay, tiscaler TI Gstreamer Plugins.