### PR TITLE
Fix ti apps launcher

### DIFF
--- a/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
+++ b/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
@@ -104,13 +104,6 @@ OECMAKE_CXX_FLAGS += "-DRT_BUILD=${RT_BUILD_VALUE}"
 EXTRA_OECMAKE = "-DOE_QMAKE_PATH_EXTERNAL_HOST_BINS=${STAGING_BINDIR_NATIVE}"
 EXTRA_OECMAKE += "-DQT_HOST_PATH=${RECIPE_SYSROOT_NATIVE}${prefix_native}"
 
-# The .so contains an ABI tag that denotes the minimum kernel version required.
-# Since Docker has no own kernel, the Docker host’s kernel version is used for
-# that comparison. Remove this check to un-break builds on some hosts.
-do_compile:prepend() {
-        strip --remove-section=.note.ABI-tag ${STAGING_LIBDIR_NATIVE}/libQt6Core.so.6.9.0
-}
-
 do_install:append() {
     if [ "${DISPLAY_CLUSTER_ENABLE}" != "1" ]; then
         install -d ${D}/opt/ti-apps-launcher

--- a/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
+++ b/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
@@ -104,6 +104,13 @@ OECMAKE_CXX_FLAGS += "-DRT_BUILD=${RT_BUILD_VALUE}"
 EXTRA_OECMAKE = "-DOE_QMAKE_PATH_EXTERNAL_HOST_BINS=${STAGING_BINDIR_NATIVE}"
 EXTRA_OECMAKE += "-DQT_HOST_PATH=${RECIPE_SYSROOT_NATIVE}${prefix_native}"
 
+# The .so contains an ABI tag that denotes the minimum kernel version required.
+# Since Docker has no own kernel, the Docker host’s kernel version is used for
+# that comparison. Remove this check to un-break builds on some hosts.
+do_compile:prepend() {
+        strip --remove-section=.note.ABI-tag ${STAGING_LIBDIR_NATIVE}/libQt6Core.so.6.9.0
+}
+
 do_install:append() {
     if [ "${DISPLAY_CLUSTER_ENABLE}" != "1" ]; then
         install -d ${D}/opt/ti-apps-launcher

--- a/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
+++ b/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
@@ -33,6 +33,7 @@ RDEPENDS:${PN} = "\
     qttools \
     qt3d \
     bash \
+    seva-launcher \
     pulseaudio-service \
     qtdeclarative-qmlplugins \
     qtwayland-qmlplugins \

--- a/meta-ti-foundational/recipes-qt/qt6/qtbase_%.bbappend
+++ b/meta-ti-foundational/recipes-qt/qt6/qtbase_%.bbappend
@@ -1,0 +1,8 @@
+# The .so contains an ABI tag that denotes the minimum kernel version required.
+# Since Docker has no own kernel, the Docker host’s kernel version is used for
+# that comparison. Remove this check to un-break builds on some hosts.
+do_install:append:class-native() {
+        strip --remove-section=.note.ABI-tag ${D}${libdir}/libQt6Core.so.6.9.0
+}
+
+PR:append = ".tisdk0"


### PR DESCRIPTION
* [meta-ti-foundational: ti-apps-launcher: Fix build errors on some hosts](https://github.com/TexasInstruments/meta-tisdk/commit/5ddce844676609805a486abc562f297f57537208)

    Below build error was seen on some host machines:
    
    ERROR: ti-apps-launcher-1.0-r19:
    recipe-sysroot-native/usr/libexec/rcc: error while loading shared libraries: libQt6Core.so.6: cannot open shared object file: No such file or directory
    
    Issue appears when building this app inside of a docker, over certain
    host machines. The ABI tag in the .so denotes the minimum kernel version
    required before loading the file. Since Docker has no own kernel, the
    Docker host's kernel is used for that comparison [0].
    
    Add the mentioned workaround here to strip the ABI tag. Qt seems to have
    fallback code, so nothing breaks.
    
    [0]: https://forum.qt.io/topic/136058/libqt6core-so-6-cannot-open-shared-object-file-even-though-it-exists-seems-to-depend-on-docker-host-os

* [meta-ti-foundational: ti-apps-launcher: Add seva-launcher back in](https://github.com/TexasInstruments/meta-tisdk/commit/8f2e64081db0f740154e54e5d61dda9187673e33)
