### PR TITLE
meta-ti-foundational: ti-apps-launcher: Add seva-launcher back in

### DIFF
--- a/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
+++ b/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
@@ -33,6 +33,7 @@ RDEPENDS:${PN} = "\
     qttools \
     qt3d \
     bash \
+    seva-launcher \
     pulseaudio-service \
     qtdeclarative-qmlplugins \
     qtwayland-qmlplugins \


### PR DESCRIPTION
Add seva-launcher back to RDEPENDS

Fixes
https://github.com/TexasInstruments/meta-tisdk/commit/2f9b4d6eb99a00168d0f7437132450ff601eb1e1