### PR TITLE
Revert "meta-ti-foundational: powervr-drivers: Add ti-img-rogue-driver bbappend"

### DIFF
--- a/meta-ti-foundational/recipes-bsp/powervr-drivers/ti-img-rogue-driver_24.2.6643903.bbappend
+++ b/meta-ti-foundational/recipes-bsp/powervr-drivers/ti-img-rogue-driver_24.2.6643903.bbappend
@@ -1,3 +1,0 @@
-PR:append = "_tisdk_0"
-
-SRCREV = "8eaff654a8871118c08cfafe53795f57e3b6b396"


### PR DESCRIPTION

This reverts commit 2f497ac1090c5b256878d803b96901d73a285840.

Since the patch to bump up the SRCREV of ti-img-rogue-driver_24.2.6643903 [1] is available on meta-ti:scarthgap as a part of 11.00.10 tag [2], stop carrying the patch in meta-tisdk.

[1]: https://git.ti.com/cgit/arago-project/meta-ti/commit/?h=scarthgap&id=8e697585943f094544eded954c98d8473f7ee1e8
[2]: https://git.ti.com/cgit/arago-project/meta-ti/tag/?h=11.00.10