### PR TITLE
recipes-bsp: am62pxx: Drop the logic from meta-ti-foundational

### DIFF
--- a/meta-ti-foundational/recipes-bsp/ti-dm-fw/ti-dm-fw.bbappend
+++ b/meta-ti-foundational/recipes-bsp/ti-dm-fw/ti-dm-fw.bbappend
@@ -1,8 +1,0 @@
-PR:append = "_tisdk_4"
-
-IPC_DM_FW = "ipc_echo_testb_mcu1_0_release_strip.xer5f"
-
-# DM FW to be used only for AM62P tisdk-display-cluster image
-DISPLAY_CLUSTER_FW = "dss_display_share.wkup-r5f0_0.release.strip.out"
-
-DM_FIRMWARE:am62pxx = "${@oe.utils.conditional("DISPLAY_CLUSTER_ENABLE", "1", "${DISPLAY_CLUSTER_FW}", "${IPC_DM_FW}", d)}"

--- a/meta-ti-foundational/recipes-bsp/u-boot/u-boot-ti-staging_2025.01.bbappend
+++ b/meta-ti-foundational/recipes-bsp/u-boot/u-boot-ti-staging_2025.01.bbappend
@@ -1,15 +1,4 @@
 SRCREV:tie-jailhouse = "cd91d73601810374d16a1f17505ab2e72e31f75d"
 
-IPC_DM_FW = "ipc_echo_testb_mcu1_0_release_strip.xer5f"
-
-# DM FW to be used only for AM62P tisdk-display-cluster image
-DISPLAY_CLUSTER_FW = "dss_display_share.wkup-r5f0_0.release.strip.out"
-
-DM_FIRMWARE:am62pxx = "${@oe.utils.conditional("DISPLAY_CLUSTER_ENABLE", "1", "${DISPLAY_CLUSTER_FW}", "${IPC_DM_FW}", d)}"
-
-TI_DM="${STAGING_DIR_HOST}${nonarch_base_libdir}/firmware/ti-dm/${PLAT_SFX}/${DM_FIRMWARE}"
-
-EXTRA_OEMAKE += "TI_DM=${TI_DM} ${@oe.utils.conditional("DISPLAY_CLUSTER_ENABLE", "1", "BINMAN_ALLOW_MISSING=1", "", d)}"
-
-PR:append = "_tisdk_5"
+PR:append = "_tisdk_6"
 


### PR DESCRIPTION
* With [0], the logic to pick two different DM R5F firmwares for tisdk-default-image & tisdk-display-cluster-image of am62pxx is now maintained in meta-ti-bsp. Hence, drop the same from meta-tisdk:meta-ti-foundational

[0]: https://git.yoctoproject.org/meta-ti/commit/?h=cicd.scarthgap.202505151402&id=87ab9adb983abaa61e4981283f1bd57a8450f4ac