### PR TITLE
meta-ti-foundational: recipes-core: Remove graphics and GPU driver packages for am62dxx

### DIFF
--- a/meta-ti-foundational/recipes-core/images/tisdk-default-image.bbappend
+++ b/meta-ti-foundational/recipes-core/images/tisdk-default-image.bbappend
@@ -8,3 +8,4 @@ IMAGE_INSTALL:append = " \
 IMAGE_INSTALL:append:am62lxx = " mosquitto libmosquitto1 libmosquittopp1 mosquitto-clients mosquitto-dev"
 IMAGE_INSTALL:append:am62xx = " ti-gst-plugins-source ti-gst-plugins-dev ti-gst-utils "
 IMAGE_INSTALL:append:am62pxx = " ti-gst-plugins-source ti-gst-plugins-dev ti-gst-utils "
+IMAGE_INSTALL:remove:am62dxx = " packagegroup-arago-tisdk-graphics" 

--- a/meta-ti-foundational/recipes-core/packagegroups/packagegroup-arago-tisdk-sourceipks-sdk-host.bb
+++ b/meta-ti-foundational/recipes-core/packagegroups/packagegroup-arago-tisdk-sourceipks-sdk-host.bb
@@ -16,6 +16,9 @@ GRAPHICS_RDEPENDS = "${@bb.utils.contains('MACHINE_FEATURES','gpu','${PREFERRED_
 # Remove GPU driver sources for j7200
 GRAPHICS_RDEPENDS:remove:j7200 = "${@bb.utils.contains('MACHINE_FEATURES','gpu','${PREFERRED_PROVIDER_virtual/gpudriver}-src','',d)}"
 
+# Remove GPU driver sources for am62dxx
+GRAPHICS_RDEPENDS:remove:am62dxx = "${@bb.utils.contains('MACHINE_FEATURES','gpu','${PREFERRED_PROVIDER_virtual/gpudriver}-src','',d)}"
+
 # Remove GPU driver sources for am62axx
 GRAPHICS_RDEPENDS:remove:am62axx = "${@bb.utils.contains('MACHINE_FEATURES','gpu','${PREFERRED_PROVIDER_virtual/gpudriver}-src','',d)}"
 


### PR DESCRIPTION
Since am62dxx doesnot have the GPU and graphics, avoid packaging them in the SDK