### PR TITLE
Update meta-ti-foundational

### DIFF
--- a/meta-ti-foundational/recipes-bsp/u-boot/u-boot-ti-staging_2025.01.bbappend
+++ b/meta-ti-foundational/recipes-bsp/u-boot/u-boot-ti-staging_2025.01.bbappend
@@ -1,4 +1,4 @@
-SRCREV:tie-jailhouse = "98b6b3f5a259be864e8db92f4925c3c19c3482a4"
+SRCREV:tie-jailhouse = "1d6ba4a32cdd8c987533d5789b5bc7b84c41fabe"
 
 PR:append = "_tisdk_6"
 

--- a/meta-ti-foundational/recipes-core/images/tisdk-core-bundle.bbappend
+++ b/meta-ti-foundational/recipes-core/images/tisdk-core-bundle.bbappend
@@ -36,7 +36,7 @@ DTB_FILTER:ti33x = "am335x"
 DTB_FILTER:ti43x = "am437x\|am43x"
 
 # All the boot partition files, including all the device variants that were built
-BOOT_PART:k3 = "uEnv.txt u-boot.img tispl.bin tiboot3.bin tiboot3-*.bin"
+BOOT_PART:k3 = "uEnv.txt u-boot.img tispl.bin tiboot3*.bin"
 BOOT_PART:append:j721e = " sysfw.itb sysfw-*evm.itb"
 BOOT_PART:append:am65xx = " sysfw.itb sysfw-*evm.itb"
 

--- a/meta-ti-foundational/recipes-kernel/linux/linux-ti-staging-rt_6.12.bbappend
+++ b/meta-ti-foundational/recipes-kernel/linux/linux-ti-staging-rt_6.12.bbappend
@@ -1,4 +1,4 @@
-SRCREV:tie-jailhouse = "05c947180bb7771d89caa530454263f8f6b93c44"
+SRCREV:tie-jailhouse = "d2e49789907c6f33ee2cb54a88a582fe9ce00d5e"
 
 PR:append = "_tisdk_8"
 

--- a/meta-ti-foundational/recipes-kernel/linux/linux-ti-staging_6.12.bbappend
+++ b/meta-ti-foundational/recipes-kernel/linux/linux-ti-staging_6.12.bbappend
@@ -1,4 +1,4 @@
-SRCREV:tie-jailhouse = "05c947180bb7771d89caa530454263f8f6b93c44"
+SRCREV:tie-jailhouse = "d2e49789907c6f33ee2cb54a88a582fe9ce00d5e"
 
 PR:append = "_tisdk_5"
 


### PR DESCRIPTION
This PR contains:
- Jailhouse SRCREV update for 11.00.15
- Update for the regular expression of tiboot3 binaries that are packaged in tisdk core bundle.