### PR TITLE
meta-ti-foundational: Update Jailhouse SRCREV for 11.01.02 tag

### DIFF
--- a/meta-ti-foundational/recipes-bsp/u-boot/u-boot-ti-staging_2025.01.bbappend
+++ b/meta-ti-foundational/recipes-bsp/u-boot/u-boot-ti-staging_2025.01.bbappend
@@ -1,4 +1,4 @@
-SRCREV:tie-jailhouse = "1d6ba4a32cdd8c987533d5789b5bc7b84c41fabe"
+SRCREV:tie-jailhouse = "da601a5231bf1b053a35c94c5d57a5658ce2e4e7"
 
 PR:append = "_tisdk_6"
 

--- a/meta-ti-foundational/recipes-kernel/linux/linux-ti-staging-rt_6.12.bbappend
+++ b/meta-ti-foundational/recipes-kernel/linux/linux-ti-staging-rt_6.12.bbappend
@@ -1,4 +1,4 @@
-SRCREV:tie-jailhouse = "d2e49789907c6f33ee2cb54a88a582fe9ce00d5e"
+SRCREV:tie-jailhouse = "c213bf2966f098202343cfa00432ef2d5f69c32c"
 
 PR:append = "_tisdk_8"
 

--- a/meta-ti-foundational/recipes-kernel/linux/linux-ti-staging_6.12.bbappend
+++ b/meta-ti-foundational/recipes-kernel/linux/linux-ti-staging_6.12.bbappend
@@ -1,4 +1,4 @@
-SRCREV:tie-jailhouse = "d2e49789907c6f33ee2cb54a88a582fe9ce00d5e"
+SRCREV:tie-jailhouse = "c213bf2966f098202343cfa00432ef2d5f69c32c"
 
 PR:append = "_tisdk_5"
 


### PR DESCRIPTION
PR for updating jailhouse SRCREV.

 This resolves the build failures observed during the am62p jailhouse builds where yocto is looking for tiboot3-am62px-hs-evm.bin for packaging. Hence update the ti-u-boot and ti-linux-kernel to latest RC tag where it is enabled.