### PR TITLE
meta-ti-foundational: recipes-demos: Change protocol from git to https

### DIFF
--- a/meta-ti-foundational/recipes-demos/benchmark-demo/benchmark-server_git.bb
+++ b/meta-ti-foundational/recipes-demos/benchmark-demo/benchmark-server_git.bb
@@ -66,9 +66,9 @@ LIC_FILES_CHKSUM = "\
 "
 
 SRC_URI = " \
-    git://git.ti.com/processor-sdk/sitara-apps.git;protocol=git;branch=master \
+    git://git.ti.com/git/processor-sdk/sitara-apps.git;protocol=https;branch=master \
     npmsw://${NPM_SHIRNKWRAP} \
-    git://git.ti.com/gui-composer-components/ti-gc-components.git;protocol=git;branch=master;destsuffix=git/benchmark_demo/webserver_app/app/components;name=guicomposer \
+    git://git.ti.com/git/gui-composer-components/ti-gc-components.git;protocol=https;branch=master;destsuffix=git/benchmark_demo/webserver_app/app/components;name=guicomposer \
 "
 SRCREV = "dc762b22701940867cc915093b865bb69317e13d"
 SRCREV_FORMAT = "default"

--- a/meta-ti-foundational/recipes-demos/opcua-server/opcua-server_git.bb
+++ b/meta-ti-foundational/recipes-demos/opcua-server/opcua-server_git.bb
@@ -2,7 +2,7 @@ SUMMARY = "OPC/UA server for experimentation"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/BSD-3-Clause;md5=550794465ba0ec5312d6919e203a55f9"
 
-SRC_URI = "git://git.ti.com/processor-sdk/sitara-apps.git;protocol=git;branch=master"
+SRC_URI = "git://git.ti.com/git/processor-sdk/sitara-apps.git;protocol=https;branch=master"
 SRCREV = "2f75495113219580eb1f5351920aa04abf43ccd0"
 PV = "0.1"
 

--- a/meta-ti-foundational/recipes-demos/pru-adc/pru-adc_git.bb
+++ b/meta-ti-foundational/recipes-demos/pru-adc/pru-adc_git.bb
@@ -12,7 +12,7 @@ PV = "1.0"
 PR = "r3"
 
 BRANCH = "master"
-SRC_URI = "git://git.ti.com/apps/tida01555.git;protocol=git;branch=${BRANCH}"
+SRC_URI = "git://git.ti.com/git/apps/tida01555.git;protocol=https;branch=${BRANCH}"
 
 SRCREV = "0a0f7700d11ec8a6b7ed02e4c70d4bf196ca35e5"
 

--- a/meta-ti-foundational/recipes-demos/sitara-ipc-app/sitara-ipc-app.bb
+++ b/meta-ti-foundational/recipes-demos/sitara-ipc-app/sitara-ipc-app.bb
@@ -6,7 +6,7 @@ COMPATIBLE_MACHINE = "am64xx"
 inherit systemd
 
 SRC_URI = " \
-    git://git.ti.com/processor-sdk/sitara-apps.git;protocol=git;branch=master \
+    git://git.ti.com/git/processor-sdk/sitara-apps.git;protocol=https;branch=master \
 "
 SRCREV = "6854fef24281893478d5d84be00d16f56b95b441"
 


### PR DESCRIPTION
In the SRC_URI, change to https protocol while cloning the dependent repositories to resolve the fetch issues during the builds.