### PR TITLE
arago-source-ipk: Drop SRCIPK overrides for unused packages

### DIFF
--- a/meta-ti-foundational/conf/distro/include/arago-source-ipk.inc
+++ b/meta-ti-foundational/conf/distro/include/arago-source-ipk.inc
@@ -84,14 +84,5 @@ SRCIPK_PRESERVE_GIT:pn-trusted-firmware-a ?= "true"
 CREATE_SRCIPK:pn-pru-icss ?= "1"
 SRCIPK_INSTALL_DIR:pn-pru-icss ?= "example-applications/${PN}-${PV}"
 
-CREATE_SRCIPK:pn-mmwavegesture-hmi ?= "1"
-SRCIPK_INSTALL_DIR:pn-mmwavegesture-hmi ?= "example-applications/${PN}-${PV}"
-
-CREATE_SRCIPK:pn-evse-hmi ?= "1"
-SRCIPK_INSTALL_DIR:pn-evse-hmi ?= "example-applications/${PN}-${PV}"
-
-CREATE_SRCIPK:pn-protection-relays-hmi ?= "1"
-SRCIPK_INSTALL_DIR:pn-protection-relays-hmi ?= "example-applications/${PN}-${PV}"
-
 CREATE_SRCIPK_pn-omapconf ?= "1"
 SRCIPK_INSTALL_DIR_pn-omapconf ?= "example-applications/${PN}-${PV}"


### PR DESCRIPTION
* Remove SRCIPK overrides from `arago-source-ipk.inc` for the following packages that are no longer being consumed,
  - mmwavegesture-hmi
  - evse-hmi
  - protection-relays-hmi

* This change helps clean up the configuration by removing unnecessary overrides for packages that are not currently being used in any builds, reducing maintenance overhead and improving clarity in the source IPK configuration.