### PR TITLE
ti-lvgl-demo: Update SRCREV to include CPU‑stats display bugfix

### DIFF
--- a/meta-ti-foundational/recipes-demos/ti-lvgl-demo/ti-lvgl-demo.bb
+++ b/meta-ti-foundational/recipes-demos/ti-lvgl-demo/ti-lvgl-demo.bb
@@ -9,7 +9,7 @@ SRC_URI = "gitsm://github.com/texasinstruments/ti-lvgl-demo.git;branch=master;pr
 S = "${WORKDIR}/git/lv_port_linux"
 B = "${S}/build-arm64"
 
-SRCREV = "b8396cf2ca51ba4cb28e71203dcfeae79de403b1"
+SRCREV = "231f5d956c83f934c6b4175870d867a61ae5bc32"
 
 inherit systemd
 SYSTEMD_PACKAGES = "${PN}"


### PR DESCRIPTION
Upstream Commit (231f5d9) fixes an issue where CPU stats did not show the total CPU usage on the demo screen.

This patch updates SRCREV to incorporate the bugfix.

Patch has been tested on a AM62L EVM 1.1 running the tisdk-default-image the CPU  usage now shows the total CPU usage.