### PR TITLE
packagegroups: Use PREFERRED_PROVIDER for adding gpudriver sources

### DIFF
--- a/meta-ti-foundational/recipes-core/packagegroups/packagegroup-arago-tisdk-sourceipks-sdk-host.bb
+++ b/meta-ti-foundational/recipes-core/packagegroups/packagegroup-arago-tisdk-sourceipks-sdk-host.bb
@@ -11,27 +11,7 @@ UBOOT_SRC = "${PREFERRED_PROVIDER_virtual/bootloader}-src"
 KERNEL_SRC = "${PREFERRED_PROVIDER_virtual/kernel}-src"
 
 # Task to install graphics sources in SDK
-GRAPHICS_RDEPENDS = "${@bb.utils.contains('MACHINE_FEATURES','gpu','${PREFERRED_PROVIDER_virtual/gpudriver}-src','',d)}"
-
-# Remove GPU driver sources for j7200
-GRAPHICS_RDEPENDS:remove:j7200 = "${@bb.utils.contains('MACHINE_FEATURES','gpu','${PREFERRED_PROVIDER_virtual/gpudriver}-src','',d)}"
-
-# Remove GPU driver sources for am62dxx
-GRAPHICS_RDEPENDS:remove:am62dxx = "${@bb.utils.contains('MACHINE_FEATURES','gpu','${PREFERRED_PROVIDER_virtual/gpudriver}-src','',d)}"
-
-# Remove GPU driver sources for am62axx
-GRAPHICS_RDEPENDS:remove:am62axx = "${@bb.utils.contains('MACHINE_FEATURES','gpu','${PREFERRED_PROVIDER_virtual/gpudriver}-src','',d)}"
-
-# Remove GPU driver sources for am64xx
-GRAPHICS_RDEPENDS:remove:am64xx = "${@bb.utils.contains('MACHINE_FEATURES','gpu','${PREFERRED_PROVIDER_virtual/gpudriver}-src','',d)}"
-
-# Remove GPU driver sources for am62lxx
-GRAPHICS_RDEPENDS:remove:am62lxx = "${@bb.utils.contains('MACHINE_FEATURES','gpu','${PREFERRED_PROVIDER_virtual/gpudriver}-src','',d)}"
-
-# Remove gpudriver sources for ti33x, ti43x and am65xx family of devices until we have SGX driver working with kernel 6.6
-GRAPHICS_RDEPENDS:remove:ti33x = "${@bb.utils.contains('MACHINE_FEATURES','gpu','${PREFERRED_PROVIDER_virtual/gpudriver}-src','',d)}"
-GRAPHICS_RDEPENDS:remove:ti43x = "${@bb.utils.contains('MACHINE_FEATURES','gpu','${PREFERRED_PROVIDER_virtual/gpudriver}-src','',d)}"
-GRAPHICS_RDEPENDS:remove:am65xx = "${@bb.utils.contains('MACHINE_FEATURES','gpu','${PREFERRED_PROVIDER_virtual/gpudriver}-src','',d)}"
+GRAPHICS_RDEPENDS = "${@d.getVar('PREFERRED_PROVIDER_virtual/gpudriver', True) and d.getVar('PREFERRED_PROVIDER_virtual/gpudriver', True) + '-src' or ''}"
 
 # Task to install crypto sources in SDK"
 CRYPTO_RDEPENDS = "cryptodev-module-src"


### PR DESCRIPTION

- MACHINE_FEATURE "gpu" from machine config includes are removed in meta-ti[0], as it does not guarantee GPU driver build.

- Use the PREFERRED_PROVIDER_virtual/gpudriver variable to add gpudriver sources in packagegroups. This approach ensures that the correct gpudriver sources are included only when the variable is defined(i.e., GPU driver is built) and non empty.

[0]: https://git.ti.com/cgit/arago-project/meta-ti/commit/?h=scarthgap&id=51cf5738f76c63009074747fccf0b298c4ce9c91