### PR TITLE
ti-lvgl-demo: fix UI does not come up on HDMI hotplug

### DIFF
--- a/meta-ti-foundational/recipes-demos/ti-lvgl-demo/files/am62lxx-evm/99-hdmi-hotplug.rules
+++ b/meta-ti-foundational/recipes-demos/ti-lvgl-demo/files/am62lxx-evm/99-hdmi-hotplug.rules
@@ -1,0 +1,4 @@
+# This udev rule automatically starts the ti-lvgl-demo
+# systemd service when an HDMI display is connected to the system
+# This is done to handle HDMI hotplug.
+ACTION=="change", KERNEL=="card0", SUBSYSTEM=="drm", ATTR{card0-HDMI-A-1/status}=="connected", TAG+="systemd", ENV{SYSTEMD_WANTS}="ti-lvgl-demo.service"

--- a/meta-ti-foundational/recipes-demos/ti-lvgl-demo/files/am62lxx-evm/ti-lvgl-demo.service
+++ b/meta-ti-foundational/recipes-demos/ti-lvgl-demo/files/am62lxx-evm/ti-lvgl-demo.service
@@ -8,6 +8,9 @@ After=multi-user.target
 
 [Service]
 Type=simple
+# Keep polling for HDMI connection for 30 secs.
+# Fail if no HDMI found. HDMI hotplug is handled by the udev rule.
+ExecStartPre=/bin/sh -c 'for i in $(seq 1 30); do grep -q "^connected$" /sys/class/drm/card*/status 2>/dev/null && exit 0; sleep 1; done; exit 1'
 ExecStart=/bin/sh -c '/usr/bin/lvglsim'
 
 # Fail to start if not controlling the tty.
@@ -15,4 +18,4 @@ StandardOutput=journal
 StandardError=journal
 
 [Install]
-WantedBy=graphical.target multi-user.target
+WantedBy=graphical.target

--- a/meta-ti-foundational/recipes-demos/ti-lvgl-demo/ti-lvgl-demo.bb
+++ b/meta-ti-foundational/recipes-demos/ti-lvgl-demo/ti-lvgl-demo.bb
@@ -10,6 +10,7 @@ SRC_URI = "gitsm://github.com/texasinstruments/ti-lvgl-demo.git;branch=${BRANCH}
            git://github.com/TexasInstruments/lv_demos.git;protocol=https;branch=${BRANCH};name=lvdemos;destsuffix=git-lvdemos \
            file://ti-lvgl-demo.service \
           "
+SRC_URI:append:am62lxx-evm = " file://99-hdmi-hotplug.rules"
 
 S = "${WORKDIR}/git/lv_port_linux"
 
@@ -53,6 +54,11 @@ do_install() {
     install -m 0644 ${WORKDIR}/ti-lvgl-demo.service ${D}${systemd_system_unitdir}/ti-lvgl-demo.service
 }
 
+do_install:append:am62lxx-evm() {
+    install -d ${D}${sysconfdir}/udev/rules.d
+    install -m 0644 ${WORKDIR}/99-hdmi-hotplug.rules ${D}${sysconfdir}/udev/rules.d/
+}
+
 FILES:${PN} += " \
     ${bindir}/lvglsim \
     ${datadir}/ti-lvgl-demo/assets \
@@ -60,3 +66,4 @@ FILES:${PN} += " \
     ${systemd_system_unitdir}/ti-lvgl-demo.service \
     ${datadir}/ti-lvgl-demo/cert/AmazonRootCA1.pem \
 "
+FILES:${PN}:append:am62lxx-evm = " ${sysconfdir}/udev/rules.d/99-hdmi-hotplug.rules"


### PR DESCRIPTION
Patch fixes the issue of UI not comming up on HDMI hotplug
* serivce runs a poll for 30s checking if Display is connected and will run only if Display is connected.
* udev rule ensures that the serivce is started on HDMI hotplug events.