### PR TITLE
Evse migration to master

### DIFF
--- a/meta-ti-foundational/conf/layer.conf
+++ b/meta-ti-foundational/conf/layer.conf
@@ -10,6 +10,11 @@ BBFILE_PATTERN_meta-ti-foundational := "^${LAYERDIR}/"
 # We keep the priority higher than all others
 BBFILE_PRIORITY_meta-ti-foundational = "12"
 
+BBFILES_DYNAMIC += " \
+    everest:${LAYERDIR}/dynamic-layers/everest/recipes*/*/*.bbappend \
+    cg5317:${LAYERDIR}/dynamic-layers/cg5317/recipes*/*/*.bbappend \
+"
+
 LAYERDEPENDS_meta-ti-foundational = " \
     core \
     meta-ti-bsp \
@@ -23,6 +28,8 @@ LAYERSERIES_COMPAT_meta-ti-foundational = "whinlatter wrynose"
 
 LAYERRECOMMENDS_meta-ti-foundational = " \
     qt6-layer \
+    everest \
+    cg5317 \
 "
 
 # Generate -src ipks packages for sources to be added to the SDK installer

--- a/meta-ti-foundational/dynamic-layers/cg5317/recipes-kernel/lms-eth2spi/lms-eth2spi.bbappend
+++ b/meta-ti-foundational/dynamic-layers/cg5317/recipes-kernel/lms-eth2spi/lms-eth2spi.bbappend
@@ -1,0 +1,6 @@
+# remove the module from autoload to be able to load it manually
+# due to a hardware quirk, and the loading of the module is taken
+# care by the host_loading_service binary supplied by Lumissil
+KERNEL_MODULE_AUTOLOAD:remove = "${MODULE_NAME}"
+
+PR:append = "_tisdk_0"

--- a/meta-ti-foundational/dynamic-layers/cg5317/recipes-tisdk/tisdk-uenv/tisdk-uenv.bbappend
+++ b/meta-ti-foundational/dynamic-layers/cg5317/recipes-tisdk/tisdk-uenv/tisdk-uenv.bbappend
@@ -1,0 +1,12 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}/${MACHINE}:"
+
+SRC_URI:append:am62lxx = "\
+    file://uEnv-am62l-sk-evse.txt \
+"
+
+do_deploy:am62lxx() {
+    install -d ${DEPLOYDIR}
+    install -m 0644 ${S}/uEnv-am62l-sk-evse.txt ${DEPLOYDIR}/uEnv.txt
+}
+
+PR:append = "_tisdk_0"

--- a/meta-ti-foundational/dynamic-layers/cg5317/recipes-tisdk/tisdk-uenv/tisdk-uenv/am62lxx-evm/uEnv-am62l-sk-evse.txt
+++ b/meta-ti-foundational/dynamic-layers/cg5317/recipes-tisdk/tisdk-uenv/tisdk-uenv/am62lxx-evm/uEnv-am62l-sk-evse.txt
@@ -1,0 +1,12 @@
+# This uEnv.txt file can contain additional environment settings that you
+# want to set in U-Boot at boot time.  This can be simple variables such
+# as the serverip or custom variables.  The format of this file is:
+#    variable=value
+# NOTE: This file will be evaluated after the bootcmd is run and the
+#       bootcmd must be set to load this file if it exists (this is the
+#       default on all newer U-Boot images.  This also means that some
+#       variables such as bootdelay cannot be changed by this file since
+#       it is not evaluated until the bootcmd is run.
+
+optargs=vt.global_cursor_default=0
+name_overlays=ti/k3-am62l3-evm-dsi-rpi-7inch-panel.dtbo ti/k3-am62l3-evm-tida-010939.dtbo

--- a/meta-ti-foundational/dynamic-layers/cg5317/recipes-utils/cg5317-utils/cg5317-utils.bbappend
+++ b/meta-ti-foundational/dynamic-layers/cg5317/recipes-utils/cg5317-utils/cg5317-utils.bbappend
@@ -1,32 +1,7 @@
-# Override files from GitHub repository
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-# Fetch from GitHub
-# SRC_URI:append = " git://github.com/TexasInstruments/tida-010939-cg5317-utils;protocol=https;branch=main;name=github"
-# SRCREV_github = "7b703f67ff6eaca2c2cff4e38d98154fc23d19c8"
+do_install:append() {
+    install -m 0644 ${D}${nonarch_base_libdir}/firmware/lumissil/spi_evse_config.bin ${D}${nonarch_base_libdir}/firmware/lumissil/config.bin
+}
 
-# do_install:append() {
-#     # Override firmware files from TI GitHub
-#     # install -m 0644 ${S}/firmware/config.bin ${D}${nonarch_base_libdir}/firmware
-#     # install -m 0644 ${S}/firmware/FW.bin ${D}${nonarch_base_libdir}/firmware
-
-#     # Override systemd services from TI GitHub
-#     #install -m 0644 ${S}/services/cg5317-host.service ${D}${sysconfdir}/systemd/system
-#     #install -m 0644 ${S}/services/cg5317-reset.service ${D}${sysconfdir}/systemd/system
-
-#     # Enable cg5317-reset.service for network.target
-#     # install -d ${D}${sysconfdir}/systemd/system/network.target.wants
-#     # ln -sf ../cg5317-reset.service ${D}${sysconfdir}/systemd/system/network.target.wants/cg5317-reset.service
-
-#     # Replace /root/examples with utils from TI GitHub
-#     rm -rf ${D}/root/examples
-#     install -d ${D}/root/examples
-
-#     # Copy all utils subdirectories
-#     cp -r ${S}/utils/* ${D}/root/examples/
-
-#     # Make all files in utils executable
-#     find ${D}/root/examples -type f -exec chmod +x {} \;
-# }
-
-PR:append = "_tisdk_0"
+PR:append = "_tisdk_1"

--- a/meta-ti-foundational/dynamic-layers/cg5317/recipes-utils/cg5317-utils/cg5317-utils.bbappend
+++ b/meta-ti-foundational/dynamic-layers/cg5317/recipes-utils/cg5317-utils/cg5317-utils.bbappend
@@ -1,0 +1,32 @@
+# Override files from GitHub repository
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+# Fetch from GitHub
+# SRC_URI:append = " git://github.com/TexasInstruments/tida-010939-cg5317-utils;protocol=https;branch=main;name=github"
+# SRCREV_github = "7b703f67ff6eaca2c2cff4e38d98154fc23d19c8"
+
+# do_install:append() {
+#     # Override firmware files from TI GitHub
+#     # install -m 0644 ${S}/firmware/config.bin ${D}${nonarch_base_libdir}/firmware
+#     # install -m 0644 ${S}/firmware/FW.bin ${D}${nonarch_base_libdir}/firmware
+
+#     # Override systemd services from TI GitHub
+#     #install -m 0644 ${S}/services/cg5317-host.service ${D}${sysconfdir}/systemd/system
+#     #install -m 0644 ${S}/services/cg5317-reset.service ${D}${sysconfdir}/systemd/system
+
+#     # Enable cg5317-reset.service for network.target
+#     # install -d ${D}${sysconfdir}/systemd/system/network.target.wants
+#     # ln -sf ../cg5317-reset.service ${D}${sysconfdir}/systemd/system/network.target.wants/cg5317-reset.service
+
+#     # Replace /root/examples with utils from TI GitHub
+#     rm -rf ${D}/root/examples
+#     install -d ${D}/root/examples
+
+#     # Copy all utils subdirectories
+#     cp -r ${S}/utils/* ${D}/root/examples/
+
+#     # Make all files in utils executable
+#     find ${D}/root/examples -type f -exec chmod +x {} \;
+# }
+
+PR:append = "_tisdk_0"

--- a/meta-ti-foundational/dynamic-layers/cg5317/recipes-utils/cg5317-utils/files/am62lxx-evm/cg5317-host@.service
+++ b/meta-ti-foundational/dynamic-layers/cg5317/recipes-utils/cg5317-utils/files/am62lxx-evm/cg5317-host@.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=CG5317_%i Host FW Loading
+After=network-online.target
+
+[Service]
+EnvironmentFile=/etc/lumissil/cg5317_%i.cfg
+User=root
+Group=root
+Type=forking
+ExecPreStart=/bin/sh -c '/usr/bin/gpioset -c gpiochip0 -p 1s -t 1s 39=1'
+ExecStart=/root/lumissil_examples/host_loading_service/host_loading_service ${RMII_FLAG} \
+                                        -f ${FW_PATH} \
+                                        -c ${CFG_PATH} \
+                                        -s ${SPI_IFNAME} \
+                                        -e ${ETH_IFNAME} \
+                                        -g ${CG_RESET_GPIO_CHIP} \
+                                        -o ${CG_RESET_GPIO_OFFSET}
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-ti-foundational/dynamic-layers/cg5317/recipes-utils/cg5317-utils/files/am62lxx-evm/cg5317-host@.service
+++ b/meta-ti-foundational/dynamic-layers/cg5317/recipes-utils/cg5317-utils/files/am62lxx-evm/cg5317-host@.service
@@ -7,7 +7,7 @@ EnvironmentFile=/etc/lumissil/cg5317_%i.cfg
 User=root
 Group=root
 Type=forking
-ExecPreStart=/bin/sh -c '/usr/bin/gpioset -c gpiochip0 -p 1s -t 1s 39=1'
+ExecPreStart=/bin/sh -c '/usr/bin/gpioset -c gpiochip0 -p 1s -t 0 39=1'
 ExecStart=/root/lumissil_examples/host_loading_service/host_loading_service ${RMII_FLAG} \
                                         -f ${FW_PATH} \
                                         -c ${CFG_PATH} \

--- a/meta-ti-foundational/dynamic-layers/cg5317/recipes-utils/cg5317-utils/files/am62lxx-evm/cg5317_0.cfg
+++ b/meta-ti-foundational/dynamic-layers/cg5317/recipes-utils/cg5317-utils/files/am62lxx-evm/cg5317_0.cfg
@@ -1,0 +1,7 @@
+RMII_FLAG=
+FW_PATH=/usr/lib/firmware/lumissil/FW.bin
+CFG_PATH=/usr/lib/firmware/config.bin
+SPI_IFNAME=seth0
+ETH_IFNAME=
+CG_RESET_GPIO_CHIP=/dev/gpiochip0
+CG_RESET_GPIO_OFFSET=39

--- a/meta-ti-foundational/dynamic-layers/cg5317/recipes-utils/cg5317-utils/files/am62lxx-evm/cg5317_0.cfg
+++ b/meta-ti-foundational/dynamic-layers/cg5317/recipes-utils/cg5317-utils/files/am62lxx-evm/cg5317_0.cfg
@@ -1,6 +1,6 @@
 RMII_FLAG=
 FW_PATH=/usr/lib/firmware/lumissil/FW.bin
-CFG_PATH=/usr/lib/firmware/config.bin
+CFG_PATH=/usr/lib/firmware/lumissil/config.bin
 SPI_IFNAME=seth0
 ETH_IFNAME=
 CG_RESET_GPIO_CHIP=/dev/gpiochip0

--- a/meta-ti-foundational/dynamic-layers/everest/recipes-core/everest/everest-core/everest.service
+++ b/meta-ti-foundational/dynamic-layers/everest/recipes-core/everest/everest-core/everest.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=EVerest
+Requires=mosquitto.service cg5317-host.service
+After=mosquitto.service cg5317-host.service
+ConditionFileNotEmpty=/etc/everest/config.yaml
+
+[Service]
+Type=simple
+Restart=always
+
+# TODO: improve startup of cg5317 to not have to wait here
+ExecStart=/bin/sh -c 'sleep 10 && /usr/bin/manager --conf /etc/everest/config.yaml'
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-ti-foundational/dynamic-layers/everest/recipes-core/everest/everest-core_%.bbappend
+++ b/meta-ti-foundational/dynamic-layers/everest/recipes-core/everest/everest-core_%.bbappend
@@ -1,0 +1,4 @@
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+PR:append = "_tisdk_0"

--- a/meta-ti-foundational/recipes-core/images/tisdk-evse-image.bb
+++ b/meta-ti-foundational/recipes-core/images/tisdk-evse-image.bb
@@ -1,0 +1,20 @@
+SUMMARY = "Arago TI SDK full image for EV Charging Supply Equipment (EVSE) on AM62L"
+
+DESCRIPTION = "Complete Arago TI SDK filesystem image containing complete \
+               applications (along with EVSE utilities) and packages intended to be used for AM62L."
+
+# Use tisdk-default-image as base
+require recipes-core/images/tisdk-default-image.bb
+
+# Ensure that we build this image only for AM62L
+COMPATIBLE_MACHINE = "am62lxx"
+
+IMAGE_INSTALL:append = " \
+    cg5317-utils \
+    kernel-module-lms-eth2spi \
+    lms-eth2spi \
+    open-plc-utils \
+    tzdata \
+"
+
+export IMAGE_BASENAME = "tisdk-evse-image${ARAGO_IMAGE_SUFFIX}"


### PR DESCRIPTION
- Brings the existing patches from scarthgap.
- cg5317-utils bbappend no longer installs TI specific firmware binaries and service files rather it relies on upstream firmware binaries and service files.  