### PR TITLE
seva-launcher: add docker-compose to RDEPENDS

### DIFF
--- a/meta-ti-foundational/recipes-demos/seva/seva-launcher.bb
+++ b/meta-ti-foundational/recipes-demos/seva/seva-launcher.bb
@@ -37,6 +37,8 @@ inherit systemd
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE:${PN} = "seva-launcher.service"
 
+RDEPENDS += " docker-compose"
+
 do_install() {
     install -d ${D}${bindir}
     install -m 0755 ${S}/seva-launcher-${LAUNCHER_SOC}-aarch64 ${D}${bindir}/seva-launcher-aarch64


### PR DESCRIPTION
seva-launcher downloads the docker-compose and packages it via its Makefile [0]. This is not standard practice and is broken in yocto master. Move away from this practice by adding docker-compose in RDEPENDS.

[0]: https://github.com/TexasInstruments/seva/blob/main/seva-launcher/Makefile#L14