### PR TITLE
qmltermwidget: Move to latest qt6 migrated terminal widget

### DIFF
--- a/meta-ti-foundational/recipes-demos/qmltermwidget/qmltermwidget.bb
+++ b/meta-ti-foundational/recipes-demos/qmltermwidget/qmltermwidget.bb
@@ -5,16 +5,16 @@ LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=4641e94ec96f98fabc56ff9cc48be14b"
 
 PV = "0.14.1+git"
-SRCREV = "ac84d444b278d5682413f7200dd324ee6c564a01"
+SRCREV = "ce8e09ad4daeb9fe59b60d6b228b0f7cf4055e16"
 
 DEPENDS = "qtbase qtdeclarative qt5compat"
 RDEPENDS:${PN} = "ttf-liberation-mono"
 
 SRC_URI = " \
-    git://github.com/kalaksi/qmltermwidget.git;protocol=https;branch=qt6-font-fix \
+    git://github.com/Swordfish90/qmltermwidget.git;protocol=https;branch=master \
     file://0001-qmltermwidget.pro-don-t-install-asset-directories-tw.patch \
 "
 
-inherit ${@bb.utils.contains('BBLAYERS', 'meta-qt6', 'qt6-qmake', '', d)}
+inherit ${@bb.utils.contains('BBFILE_COLLECTIONS', 'qt6-layer', 'qt6-qmake', '', d)}
 
 FILES:${PN} += "${libdir}"

--- a/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
+++ b/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher.bb
@@ -35,6 +35,7 @@ RDEPENDS:${PN} = "\
     bash \
     seva-launcher \
     pulseaudio-service \
+    qmltermwidget \
     qtdeclarative-qmlplugins \
     qtwayland-qmlplugins \
     qtdeclarative-tools \
@@ -58,7 +59,7 @@ RDEPENDS:${PN}:append:am62xx = " powervr-graphics"
 RDEPENDS:${PN}:append:am62pxx = " powervr-graphics"
 
 BRANCH = "master"
-SRCREV = "955bc28d39a5718949f4eb9146ef40d7b06a022f"
+SRCREV = "6c2ef5d86ffc637e4dd63d798b6f831cd2af8b31"
 
 SRC_URI = " \
     git://github.com/TexasInstruments/ti-apps-launcher.git;protocol=https;branch=${BRANCH} \


### PR DESCRIPTION
Move to the repository that enables latest working Qt6 supported QML Terminal widget.