### PR TITLE
seva-launcher: fix build error due to RDEPENDS not being package specific

### DIFF
--- a/meta-ti-foundational/recipes-demos/seva/seva-launcher.bb
+++ b/meta-ti-foundational/recipes-demos/seva/seva-launcher.bb
@@ -37,7 +37,7 @@ inherit systemd
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE:${PN} = "seva-launcher.service"
 
-RDEPENDS += " docker-compose"
+RDEPENDS:${PN} += " docker-compose"
 
 do_install() {
     install -d ${D}${bindir}


### PR DESCRIPTION
RDEPENDS += " docker-compose" gives error "Variable RDEPENDS is
set as not being package specific, please fix this. [pkgvarcheck]"
Patch fixes this issue.

