### PR TITLE
tisdk-core-bundle: Ensure SDPX image tasks are run for all images

### DIFF
--- a/meta-ti-foundational/recipes-core/images/tisdk-core-bundle.bb
+++ b/meta-ti-foundational/recipes-core/images/tisdk-core-bundle.bb
@@ -21,3 +21,7 @@ TARGET_IMAGE_TYPES = "tar.xz wic.xz wic.bmap"
 IMAGE_INSTALL:append = " \
     packagegroup-arago-tisdk-sourceipks-sdk-host \
 "
+
+# Ensure SPDX image tasks are run for all TARGET_IMAGES
+# This forces complete SPDX generation (image, rootfs, and package level) for each image in the bundle
+do_create_image_sbom_spdx[depends] += "${@' '.join(['%s:do_create_image_sbom_spdx' % pn for pn in (d.getVar('TARGET_IMAGES') or '').split()])}"


### PR DESCRIPTION
Building tisdk-core-bundle builds images defined in TARGET_IMAGES but does not generate SPDX for each image. This is because the images are treated as packages for tisdk-core-bundle.

Patch ensures that the do_create_image_sbom_spdx task is run for each target images so that the SPDX SBOM is generated for each image.