### PR TITLE
ti-gst-plugins: Fix cross-compilation and QA issues

### DIFF
--- a/meta-ti-foundational/recipes-multimedia/gst-plugins-ti/ti-gst-plugins.bb
+++ b/meta-ti-foundational/recipes-multimedia/gst-plugins-ti/ti-gst-plugins.bb
@@ -28,12 +28,19 @@ FILES:${PN} += "${libdir}/gstreamer-1.0/*.so"
 EXTRA_OEMESON = "--prefix=/usr -Dpkg_config_path=${S}/pkgconfig -Ddl-plugins=disabled -Denable-tidl=disabled"
 
 inherit meson pkgconfig
+ 
+do_configure:prepend() {
+    # Fix pkg-config files for cross-compilation
+    sed -i "s|^prefix=/usr|prefix=${STAGING_DIR_TARGET}/usr|g" ${S}/pkgconfig/*.pc
+}
 
 do_install:append() {
     CP_ARGS="-Prf --preserve=mode,timestamps --no-preserve=ownership"
 
     mkdir -p ${D}/opt/edgeai-gst-plugins
     cp ${CP_ARGS} ${S}/* ${D}/opt/edgeai-gst-plugins
+
+    sed -i "s|${STAGING_DIR_TARGET}/usr|/usr|g" ${D}/opt/edgeai-gst-plugins/pkgconfig/*.pc
 }
 
 INSANE_SKIP:${PN}-source += "dev-deps"


### PR DESCRIPTION
The ti-gst-plugins build was failing with multiple issues:
1. Cross-compilation error: The build used hardcoded host paths (-I/usr/include/edgeai-apps-utils/) which triggered poison-system- directories error and caused missing header file failures.
2. QA buildpaths error: pkg-config files contained TMPDIR references from build-time modifications, violating the buildpaths QA check.

Fixes applied:
  - Add do_configure:prepend() to modify pkg-config files with proper cross-compilation paths (${STAGING_DIR_TARGET}) instead of hardcoded host paths
  - Update do_install:append() to copy required pkg-config files to the final package location
  - Clean up pkg-config files in do_install to remove TMPDIR references and avoid buildpaths QA failures

This resolves both the compilation failures due to unsafe include paths and the QA errors from build-time directory references in packaged files.

Sanity Test logs: https://gist.github.com/PrathamTI/09c30a0c5b311fd6442a00f6b8844b73