### PR TITLE
tensorflow-lite: Fix header packaging and resolve QA .so symlink errors

### DIFF
--- a/meta-ti-ml/recipes-core/images/tisdk-default-image.bbappend
+++ b/meta-ti-ml/recipes-core/images/tisdk-default-image.bbappend
@@ -2,6 +2,7 @@ PR:append = "_tisdk_ml_0"
 
 IMAGE_INSTALL:append = " \
     tensorflow-lite \
+    tensorflow-lite-dev \
     onnx \
     onnxruntime \
     onnxruntime-tests \

--- a/meta-ti-ml/recipes-framework/tensorflow-lite/tensorflow-lite_%.bbappend
+++ b/meta-ti-ml/recipes-framework/tensorflow-lite/tensorflow-lite_%.bbappend
@@ -1,0 +1,5 @@
+# This appends the dev files to the -dev in tensorflow-lite
+FILES:${PN}-dev += " \
+    ${includedir}/* \
+    ${libdir}/lib*.so \
+"


### PR DESCRIPTION
This commit addresses two issues with TensorFlow Lite packaging:

1. Missing headers in image: Headers were being installed during do_install but not packaged into any specific package, causing them to be missing from the final rootfs despite being built correctly.

2. QA error with .so symlinks: Yocto QA was failing because unversioned .so symlinks (libtensorflow-lite.so, libtensorflowlite.so) were placed in the main runtime package instead of the development package.

Changes made:

   - Created tensorflow-lite_%.bbappend to properly assign development files (headers and unversioned .so symlinks) to the -dev package

   - Added tensorflow-lite-dev to tisdk-default-image to ensure headers are included in the final image for development use cases

This resolves the QA issue [dev-so] and ensures TensorFlow Lite headers are available.