### PR TITLE
tisdk-uenv: fix typo in uEnv filename

### DIFF
--- a/meta-ti-foundational/recipes-tisdk/tisdk-uenv/tisdk-uenv.bbappend
+++ b/meta-ti-foundational/recipes-tisdk/tisdk-uenv/tisdk-uenv.bbappend
@@ -28,7 +28,7 @@ do_deploy:am62pxx() {
 
 do_deploy:am62lxx-evm() {
     install -d ${DEPLOYDIR}
-    install -m 0644 ${S}/uEnv-am62l-sk.txt ${DEPLOYDIR}/uEnv.txt
+    install -m 0644 ${S}/uEnv-am62l-evm.txt ${DEPLOYDIR}/uEnv.txt
 }
 
 PR:append = "_tisdk_1"


### PR DESCRIPTION
Fixes the typo in the uEnv.txt filename. Typo causes build failures due to the file not being found in do_deploy() .