### PR TITLE
meta-ti-foundational: integrate Slint UI framework via dynamic-layers

### DIFF
--- a/meta-ti-foundational/conf/layer.conf
+++ b/meta-ti-foundational/conf/layer.conf
@@ -13,6 +13,8 @@ BBFILE_PRIORITY_meta-ti-foundational = "12"
 BBFILES_DYNAMIC += " \
     everest:${LAYERDIR}/dynamic-layers/everest/recipes*/*/*.bbappend \
     cg5317:${LAYERDIR}/dynamic-layers/cg5317/recipes*/*/*.bbappend \
+    meta-slint:${LAYERDIR}/dynamic-layers/meta-slint/recipes*/*/*.bb \
+    meta-slint:${LAYERDIR}/dynamic-layers/meta-slint/recipes*/*/*.bbappend \
 "
 
 LAYERDEPENDS_meta-ti-foundational = " \
@@ -33,6 +35,10 @@ LAYERRECOMMENDS_meta-ti-foundational = " \
 "
 
 IMAGE_FSTYPES:remove:beaglebadge-ti = " ubifs ubi"
+
+# Pin slint-cpp to a stable release
+PREFERRED_VERSION_slint-cpp ?= "1.15.0"
+PREFERRED_VERSION_slint-cpp-native ?= "1.15.0"
 
 # Generate -src ipks packages for sources to be added to the SDK installer
 require conf/distro/include/arago-source-ipk.inc

--- a/meta-ti-foundational/dynamic-layers/meta-slint/recipes-core/images/tisdk-default-image.bbappend
+++ b/meta-ti-foundational/dynamic-layers/meta-slint/recipes-core/images/tisdk-default-image.bbappend
@@ -1,0 +1,3 @@
+IMAGE_INSTALL:append = " slint-demos"
+
+PR:append = "_tisdk_0"

--- a/meta-ti-foundational/dynamic-layers/meta-slint/recipes-graphics/slint/slint-demos_%.bbappend
+++ b/meta-ti-foundational/dynamic-layers/meta-slint/recipes-graphics/slint/slint-demos_%.bbappend
@@ -1,0 +1,8 @@
+# Default to software renderer for all TI SDK targets.
+SLINT_RENDERER = "software"
+
+# Enable LTO for software renderer builds (no Skia = no RAM pressure).
+# Gives 5-15% runtime improvement, especially beneficial on Cortex-A53
+do_compile:prepend() {
+    export CARGO_PROFILE_RELEASE_LTO=true
+}


### PR DESCRIPTION
Add support for building and installing Slint demos in TI SDK images when the meta-slint layer is present. All Slint-specific content is gated behind BBFILES_DYNAMIC so it only activates when meta-slint is in bblayers.conf, with zero impact on builds without it.