### PR TITLE
tensorflow-lite: Remove bbappend as headers are provided by tensorflow-lite-dev

### DIFF
--- a/meta-ti-ml/recipes-framework/tensorflow-lite/tensorflow-lite_%.bbappend
+++ b/meta-ti-ml/recipes-framework/tensorflow-lite/tensorflow-lite_%.bbappend
@@ -1,5 +1,0 @@
-# This appends the dev files to the -dev in tensorflow-lite
-FILES:${PN}-dev += " \
-    ${includedir}/* \
-    ${libdir}/lib*.so \
-"


### PR DESCRIPTION
This bbappend is no longer needed as the fix for TensorFlow Lite header packaging has been submitted to meta-arago in the main recipe.

Patch Link: https://patchwork.yoctoproject.org/project/arago/patch/20260423075408.1886225-2-p-deshmukh@ti.com/