### PR TITLE
pulseaudio-service: workaround groupmems --prefix breakage

### DIFF
--- a/meta-ti-foundational/recipes-multimedia/pulseaudio/pulseaudio-service.bb
+++ b/meta-ti-foundational/recipes-multimedia/pulseaudio/pulseaudio-service.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "Pulseaudio systemd service"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-inherit systemd useradd
+inherit systemd
 
 DEPENDS = "pulseaudio"
 
@@ -17,8 +17,11 @@ FILES:${PN} = " \
     ${systemd_unitdir} \
 "
 
-USERADD_PACKAGES = "pulseaudio-service"
-GROUPMEMS_PARAM:${PN} = " --add root --group audio"
+RDEPENDS:${PN} += "shadow"
+
+pkg_postinst:${PN}() {
+    usermod -a -G audio root
+}
 
 do_install:append() {
     if ${@bb.utils.contains('DISTRO_FEATURES','systemd','true','false',d)}; then


### PR DESCRIPTION
Recent oe-core commit [0] switched useradd.bbclass from --root to --prefix, but groupmems in shadow lacks --prefix support, causing do_prepare_recipe_sysroot to fail with "unrecognized option '--prefix'".

Replace GROUPMEMS_PARAM with pkg_postinst using usermod (which supports
 --prefix) to add root to the audio group.

[0]: https://git.openembedded.org/openembedded-core/commit/?id=a7b846ba7d6d63a5e59939d75d9c5fe3e4cbb0e9