### PR TITLE
jailhouse: update SRCREV for jailhouse linux and uboot

### DIFF
--- a/meta-ti-foundational/recipes-bsp/u-boot/u-boot-ti-staging_2026.01.bbappend
+++ b/meta-ti-foundational/recipes-bsp/u-boot/u-boot-ti-staging_2026.01.bbappend
@@ -1,3 +1,3 @@
-SRCREV_uboot:tie-jailhouse:bsp-ti-6_18 = "68815db7c151cfff139e6d600785c682d11e4d62"
+SRCREV_uboot:tie-jailhouse:bsp-ti-6_18 = "a0b0caf092a7a0ef0066a8f77c06d1acf8757093"
 
 PR:append = "_tisdk_0"

--- a/meta-ti-foundational/recipes-kernel/linux/linux-ti-staging-rt_6.18.bbappend
+++ b/meta-ti-foundational/recipes-kernel/linux/linux-ti-staging-rt_6.18.bbappend
@@ -1,3 +1,3 @@
-SRCREV:tie-jailhouse:bsp-ti-6_18 = "c2de33f23a2fe523dc002230fb263d6f88090553"
+SRCREV:tie-jailhouse:bsp-ti-6_18 = "77f514520ac094a2de650130512410775aa1d042"
 
 PR:append = "_tisdk_0"

--- a/meta-ti-foundational/recipes-kernel/linux/linux-ti-staging_6.18.bbappend
+++ b/meta-ti-foundational/recipes-kernel/linux/linux-ti-staging_6.18.bbappend
@@ -1,3 +1,3 @@
-SRCREV:tie-jailhouse:bsp-ti-6_18 = "c2de33f23a2fe523dc002230fb263d6f88090553"
+SRCREV:tie-jailhouse:bsp-ti-6_18 = "77f514520ac094a2de650130512410775aa1d042"
 
 PR:append = "_tisdk_0"


### PR DESCRIPTION
Update tie-jailhouse:bsp-ti-6_18 linux and uboot
SRCREV to latest 12.01.00.02 RC