### PR TITLE
webserver-oob: use SOC_FAMILY overrides and scope packagegroup correctly

### DIFF
--- a/meta-ti-foundational/recipes-core/packagegroups/packagegroup-arago-addons.bbappend
+++ b/meta-ti-foundational/recipes-core/packagegroups/packagegroup-arago-addons.bbappend
@@ -1,16 +1,14 @@
 PR:append = "_tisdk_3"
 
 DEMOS = ""
-DEMOS:append:am62xx = " ti-apps-launcher"
-DEMOS:append:am62pxx = " ti-apps-launcher"
-DEMOS:append:am62lxx-evm = " ti-lvgl-demo"
+DEMOS:append:am62xx = " ti-apps-launcher webserver-oob"
+DEMOS:append:am62pxx = " ti-apps-launcher webserver-oob"
+DEMOS:append:am62lxx-evm = " ti-lvgl-demo webserver-oob"
 DEMOS:append:foundational = " ti-apps-launcher"
-DEMOS:append:am62dxx-evm = " ti-librpmsg-dma-example"
-DEMOS:append:am335x-evm = " ti-lvgl-demo"
+DEMOS:append:am62dxx-evm = " ti-librpmsg-dma-example webserver-oob"
+DEMOS:append:am335x-evm = " ti-lvgl-demo webserver-oob"
 DEMOS:append:am437x-evm  = " ti-lvgl-demo"
 DEMOS:append:am65xx-evm  = " ti-lvgl-demo"
-
-DEMOS:append = " webserver-oob"
 
 DEMOS:append:am64xx = " \
     benchmark-server \

--- a/meta-ti-foundational/recipes-demos/webserver-oob/webserver-oob_git.bb
+++ b/meta-ti-foundational/recipes-demos/webserver-oob/webserver-oob_git.bb
@@ -1,17 +1,16 @@
 SUMMARY = "Out-of-box web server for demonstrating example application demos"
 LICENSE = "BSD-3-Clause & MIT & ISC"
 
-COMPATIBLE_MACHINE = "am335x-evm|am62xx-evm|am62xxsip-evm|am62xx-lp-evm|am62pxx-evm|am62lxx-evm|am62dxx-evm"
+COMPATIBLE_MACHINE = "ti33x|am62xx|am62pxx|am62lxx|am62dxx"
 
 # Maps to repo devices/<DEVICE_ID>/ directory.
 # Use SOC_FAMILY overrides where one override covers multiple machines.
-# am335x has SOC_FAMILY=ti33x so we fall back to explicit machine name.
-DEVICE_ID             = "unknown"
-DEVICE_ID:am335x-evm  = "am335x"
-DEVICE_ID:am62xx      = "am62xx"
-DEVICE_ID:am62pxx     = "am62pxx"
-DEVICE_ID:am62lxx     = "am62lxx"
-DEVICE_ID:am62dxx     = "am62dxx"
+DEVICE_ID = "unknown"
+DEVICE_ID:ti33x = "am335x"
+DEVICE_ID:am62xx = "am62xx"
+DEVICE_ID:am62pxx = "am62pxx"
+DEVICE_ID:am62lxx = "am62lxx"
+DEVICE_ID:am62dxx = "am62dxx"
 
 # NPM pulls in many "independent" packages into a single app package
 LIC_FILES_CHKSUM = "\


### PR DESCRIPTION
Replace explicit machine names in COMPATIBLE_MACHINE and DEVICE_ID with SOC_FAMILY overrides (ti33x, am62xx, am62pxx, am62lxx, am62dxx), covering all current and future machine variants within each family automatically.

Drop the unconditional DEMOS:append in packagegroup-arago-addons.bbappend that added webserver-oob for all machines and scope it to the supported devices instead.