### PR TITLE
Revert "layer-conf: remove building ubifs for beaglebadge-ti"

### DIFF
--- a/meta-ti-foundational/conf/layer.conf
+++ b/meta-ti-foundational/conf/layer.conf
@@ -34,8 +34,6 @@ LAYERRECOMMENDS_meta-ti-foundational = " \
     cg5317 \
 "
 
-IMAGE_FSTYPES:remove:beaglebadge-ti = " ubifs ubi"
-
 # Pin slint-cpp to a stable release
 PREFERRED_VERSION_slint-cpp ?= "1.15.0"
 PREFERRED_VERSION_slint-cpp-native ?= "1.15.0"


### PR DESCRIPTION
This reverts commit 7dbee113d4a1eaf46fb4c6a0981eb86300263d75. 
No longer needed since the ubifs is disabled in meta-ti for beaglebadge-ti.

Link - https://git.ti.com/cgit/arago-project/meta-ti/commit/?h=wrynose&id=3e88e2e2c320ed5960d1f539c9f210a2ed1e7c0f