### PR TITLE
meta-ti-foundational: expose TISDK_VERSION in /etc/os-release

### DIFF
--- a/meta-ti-foundational/conf/layer.conf
+++ b/meta-ti-foundational/conf/layer.conf
@@ -42,3 +42,5 @@ PREFERRED_VERSION_slint-cpp-native ?= "1.15.0"
 
 # Generate -src ipks packages for sources to be added to the SDK installer
 require conf/distro/include/arago-source-ipk.inc
+
+include conf/tisdk-release.conf

--- a/meta-ti-foundational/conf/tisdk-release.conf
+++ b/meta-ti-foundational/conf/tisdk-release.conf
@@ -1,0 +1,1 @@
+TISDK_VERSION = "live"

--- a/meta-ti-foundational/recipes-core/os-release/os-release.bbappend
+++ b/meta-ti-foundational/recipes-core/os-release/os-release.bbappend
@@ -1,0 +1,3 @@
+# Append TISDK_VERSION to /etc/os-release
+# Value comes from meta-ti-foundational/conf/tisdk-release.conf
+OS_RELEASE_FIELDS:append = " TISDK_VERSION"


### PR DESCRIPTION
Currently there was no way to identify which TISDK release was flashed on a board from the running filesystem. TISDK_VERSION was defined in arago.conf[0] but never written to the rootfs.

Add tisdk-release.conf as the single source of truth for the release version which gets updated for every CICD tag or release candidate. And os-release bbappend appends TISDK_VERSION to OS_RELEASE_FIELDS, making it visible in /etc/os-release on the target.

[0]: https://git.ti.com/cgit/arago-project/meta-arago/tree/meta-arago-distro/conf/distro/arago.conf?h=master#n6