### PR TITLE
Revert "ti-apps-launcher: Enable Maximized window mode by default"

### DIFF
--- a/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher/ti-apps-launcher.service
+++ b/meta-ti-foundational/recipes-demos/ti-apps-launcher/ti-apps-launcher/ti-apps-launcher.service
@@ -13,7 +13,6 @@ Environment=QT_QPA_PLATFORM=wayland
 Environment=WAYLAND_DISPLAY=wayland-1
 Environment=QML_DISABLE_DISK_CACHE=1
 Environment=QT_DISABLE_SHADER_DISK_CACHE=1
-Environment=TI_APPS_WINDOW_MODE=Maximized
 EnvironmentFile=/etc/environment
 ExecStartPre=/bin/sh -c 'while [ ! -S /run/user/1000/wayland-1 ]; do sleep 1; done'
 ExecStart=/bin/sh -c '/usr/bin/ti-apps-launcher'


### PR DESCRIPTION
This reverts commit 4bf63ff7da82d158edf100456434db7e789b6d0f.

The windowed mode workaround was needed because the mouse cursor was obscured by the Qt app when using the meta-qt6 dev branch. This issue is no longer seen with the Qt 6.11 branch, so revert to fullscreen mode.