### PR TITLE
arm-compute-library: Add missing examples package in IMAGE_INSTALL

### DIFF
--- a/meta-ti-ml/recipes-core/images/tisdk-default-image.bbappend
+++ b/meta-ti-ml/recipes-core/images/tisdk-default-image.bbappend
@@ -9,6 +9,7 @@ IMAGE_INSTALL:append = " \
     armnn \
     arm-compute-library \
     arm-compute-library-tests \
+    arm-compute-library-examples \
     nnstreamer \
     nnstreamer-tests \
     nnshark \


### PR DESCRIPTION
The arm-compute-library-examples package was missing from the default rootfs IMAGE_INSTALL, which resulted in missing ACL example applications.

Add arm-compute-library-examples to IMAGE_INSTALL for tisdk-default-image.