### PR TITLE
ti-lvgl-demo: update SRCREV and service file for am62lxx-evm

### DIFF
--- a/meta-ti-foundational/recipes-demos/ti-lvgl-demo/files/am62lxx-evm/ti-lvgl-demo.service
+++ b/meta-ti-foundational/recipes-demos/ti-lvgl-demo/files/am62lxx-evm/ti-lvgl-demo.service
@@ -1,14 +1,15 @@
 # This is a system unit for launching ti-lvgl-demo.
-
 [Unit]
 Description=ti-lvgl-demo service
-
-# Make sure we are started after logins are permitted.
 After=multi-user.target
 
 [Service]
 Type=simple
+ExecStartPre=/bin/sh -c 'echo 0 > /sys/class/vtconsole/vtcon1/bind'
+ExecStartPre=/bin/sh -c 'systemctl stop getty@tty1.service || true'
 ExecStart=/bin/sh -c '/usr/bin/lvglsim'
+ExecStopPost=/bin/sh -c 'echo 1 > /sys/class/vtconsole/vtcon1/bind'
+ExecStopPost=/bin/sh -c 'systemctl start getty@tty1.service || true'
 
 # Fail to start if not controlling the tty.
 StandardOutput=journal

--- a/meta-ti-foundational/recipes-demos/ti-lvgl-demo/ti-lvgl-demo.bb
+++ b/meta-ti-foundational/recipes-demos/ti-lvgl-demo/ti-lvgl-demo.bb
@@ -14,7 +14,7 @@ SRC_URI = "gitsm://github.com/texasinstruments/ti-lvgl-demo.git;branch=${BRANCH}
 S = "${UNPACKDIR}/${BB_GIT_DEFAULT_DESTSUFFIX}/lv_port_linux"
 
 SRCREV_main = "edc14fdab29376d9642ee057c9a2095fdc58416a"
-SRCREV_main:am62lxx-evm = "a69da8bd3a163e3ee7eebc96b34fd51f0788fdb8"
+SRCREV_main:am62lxx-evm = "346dc2971873333a2451e1ccd466358154800c34"
 SRCREV_lvdemos = "de9c755979b690a2064b80d993bd14f0be7eff5b"
 SRCREV_lvdemos:am62lxx-evm = "8e41791a2dce961ff9e157b413dcea2217301146"
 SRCREV_FORMAT = "main_lvdemos"


### PR DESCRIPTION
This PR updates the ti-lvgl-demo recipe with the latest source revision and fixes the systemd service configuration for the am62lxx-evm platform.

Changes-:

Update to latest SRCREV
- Bumped ti-lvgl-demo to the latest SRCREV for the am62lxx-evm platform.

Fix am62lxx service file
- Updated the ti-lvgl-demo service file to disable the framebuffer console, which is enabled by default and conflicts with the LVGL demo.
Stopped the getty services to prevent keyboard access to the board while the LVGL demo is running, ensuring the demo has exclusive control of the display.