### PR TITLE
[master] tisdk-tiny-initramfs: handle init managers conditionally

### DIFF
--- a/meta-ti-foundational/recipes-core/images/tisdk-tiny-initramfs.bb
+++ b/meta-ti-foundational/recipes-core/images/tisdk-tiny-initramfs.bb
@@ -12,12 +12,17 @@ require recipes-core/images/arago-tiny-initramfs.bb
 # Enable passwordless root login (user types "root", no password asked)
 IMAGE_FEATURES += "empty-root-password"
 
-PACKAGE_INSTALL = " \
+# Essential packages for a functional initramfs
+TISDK_INITRAMFS_ESSENTIALS = " \
     base-files \
     base-passwd \
-    busybox \
+    ${VIRTUAL-RUNTIME_base-utils} \
+    ${VIRTUAL-RUNTIME_login_manager} \
+"
+
+# Additional utilities (can be overridden or emptied for minimal image size)
+TISDK_INITRAMFS_UTILITIES ?= " \
     netbase \
-    shadow-base \
     update-alternatives-opkg \
     parted \
     util-linux \
@@ -30,3 +35,11 @@ PACKAGE_INSTALL = " \
     wget \
     dropbear \
 "
+
+PACKAGE_INSTALL = "${TISDK_INITRAMFS_ESSENTIALS} ${TISDK_INITRAMFS_UTILITIES}"
+
+# Conditionally add sysvinit and initscripts when distro uses sysvinit, else systemd
+PACKAGE_INSTALL:append = "${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', ' ${VIRTUAL-RUNTIME_init_manager} ${VIRTUAL-RUNTIME_initscripts}', 'systemd', d)}"
+
+# Set INITRAMFS_MAXSIZE as 64MB for sysvinit, 256MB for systemd
+INITRAMFS_MAXSIZE = "${@bb.utils.contains('DISTRO_FEATURES', 'sysvinit', '65536', '262144', d)}"


### PR DESCRIPTION
Dynamically configure package installation and maximum size limit based on the active init manager in DISTRO_FEATURES. This ensures initramfs support across both sysvinit and systemd distributions.

Also, set limit via INITRAMFS_MAXSIZE to 64MB for lightweight sysvinit environments and 256MB for resource-heavy systemd frameworks.

Refactor the package installation structure by splitting packages into essential components and optional utilities, to enable overrides for minimal image requirements.