### PR TITLE
meta-slint: upgrade slint to v1.17.1

### DIFF
--- a/meta-ti-foundational/conf/layer.conf
+++ b/meta-ti-foundational/conf/layer.conf
@@ -35,8 +35,8 @@ LAYERRECOMMENDS_meta-ti-foundational = " \
 "
 
 # Pin slint-cpp to a stable release
-PREFERRED_VERSION_slint-cpp ?= "1.15.0"
-PREFERRED_VERSION_slint-cpp-native ?= "1.15.0"
+PREFERRED_VERSION_slint-cpp ?= "1.17.1"
+PREFERRED_VERSION_slint-cpp-native ?= "1.17.1"
 
 # Generate -src ipks packages for sources to be added to the SDK installer
 require conf/distro/include/arago-source-ipk.inc

--- a/meta-ti-foundational/dynamic-layers/meta-slint/recipes-core/images/tisdk-default-image.bbappend
+++ b/meta-ti-foundational/dynamic-layers/meta-slint/recipes-core/images/tisdk-default-image.bbappend
@@ -1,3 +1,3 @@
-IMAGE_INSTALL:append = " slint-demos"
+IMAGE_INSTALL:append = " slint-demos slint-viewer liberation-fonts"
 
 PR:append = "_tisdk_0"

--- a/meta-ti-foundational/dynamic-layers/meta-slint/recipes-example/slint-demos/slint-demos_%.bbappend
+++ b/meta-ti-foundational/dynamic-layers/meta-slint/recipes-example/slint-demos/slint-demos_%.bbappend
@@ -1,0 +1,2 @@
+# For AM62L (no GPU), remove OpenGL demos that require GPU
+SLINT_DEMOS:am62lxx-evm = "slide_puzzle printerdemo gallery energy-monitor home-automation"

--- a/meta-ti-foundational/dynamic-layers/meta-slint/recipes-graphics/slint/slint-demos_%.bbappend
+++ b/meta-ti-foundational/dynamic-layers/meta-slint/recipes-graphics/slint/slint-demos_%.bbappend
@@ -1,8 +1,0 @@
-# Default to software renderer for all TI SDK targets.
-SLINT_RENDERER = "software"
-
-# Enable LTO for software renderer builds (no Skia = no RAM pressure).
-# Gives 5-15% runtime improvement, especially beneficial on Cortex-A53
-do_compile:prepend() {
-    export CARGO_PROFILE_RELEASE_LTO=true
-}


### PR DESCRIPTION
Bump up to v1.17.1 to enable upstream support for AM62P and
AM62L devices[0].

Add slint-viewer and liberation-fonts to tisdk-default-image
for .slint file preview and font rendering.

Split autostart (service and udev rules) files into separate
packages so that when tisdk-default-image installs only
slint-demos (binaries) for manual launch, and ti-image-slint-
demos[1] installs autostart files to launch the demos out-of-box.

Modify the directory structure following the upstream meta-slint
convention.

[0]: https://github.com/slint-ui/meta-slint/commit/12a2ebb48d4f7f2dbe06d1d9a33c094918cc9a3c
[1]: https://github.com/slint-ui/meta-slint/blob/dev/dynamic-layers/meta-ti/recipes-graphics/images/ti-image-slint-demos.bb
