### PR TITLE
webserver-oob: add speech-to-text demo

### DIFF
--- a/meta-ti-foundational/recipes-demos/webserver-oob/webserver-oob_git.bb
+++ b/meta-ti-foundational/recipes-demos/webserver-oob/webserver-oob_git.bb
@@ -95,13 +95,22 @@ SRC_URI = " \
     git://git.ti.com/git/gui-composer-components/ti-gc-components.git;protocol=https;branch=master;destsuffix=${BB_GIT_DEFAULT_DESTSUFFIX}/common/app/components;name=guicomposer \
     ${NPM_SRC_URI} \
 "
-SRCREV = "8b5947ff2c3bbe6b01d7e6c968c24815a3ef1086"
+SRCREV = "297f002e65c4eceb172706049f703bed7db4152e"
 SRCREV_guicomposer = "18115d266ba9f1956d06258ce2c8997fd1ef2efe"
 SRCREV_FORMAT = "default"
 PV = "1.0.0"
 
 RDEPENDS:${PN} = "nodejs tensorflow-lite nnstreamer analytics-demo-data"
 RDEPENDS:${PN}:append:am64xx = " benchmark-demo-firmware"
+# speech-to-text support for am62pxx, am62xx, am62lxx
+RDEPENDS:${PN}:append:am62pxx = " gstreamer1.0 glib-2.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good onnxruntime"
+RDEPENDS:${PN}:append:am62xx = " gstreamer1.0 glib-2.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good onnxruntime"
+RDEPENDS:${PN}:append:am62lxx = " gstreamer1.0 glib-2.0 gstreamer1.0-plugins-base gstreamer1.0-plugins-good onnxruntime"
+
+# Build-time GStreamer headers for speech_utils cross-compilation (am62pxx, am62xx, am62lxx)
+DEPENDS:append:am62pxx = " gstreamer1.0 glib-2.0"
+DEPENDS:append:am62xx = " gstreamer1.0 glib-2.0"
+DEPENDS:append:am62lxx = " gstreamer1.0 glib-2.0"
 
 WEBSERVER_ROOT = "${UNPACKDIR}/${BB_GIT_DEFAULT_DESTSUFFIX}"
 S = "${WEBSERVER_ROOT}/common/webserver"
@@ -110,7 +119,7 @@ S = "${WEBSERVER_ROOT}/common/webserver"
 DEBUG_PREFIX_MAP:append = " -ffile-prefix-map=${WEBSERVER_ROOT}=/usr/src/debug/${PN}/${EXTENDPE}${PV}-${PR}"
 
 TARGET_CC_ARCH += "${LDFLAGS}"
-inherit systemd
+inherit pkgconfig systemd
 
 # Extract npm tarballs to node_modules, stripping top-level package/ directory.
 # Runs after do_unpack (git sources ready) and before do_patch (for license checks).
@@ -179,6 +188,9 @@ do_install() {
     if [ -f ${WEBSERVER_ROOT}/devices/${DEVICE_ID}/linux_app/audio_utils ]; then
         install -m 0755 ${WEBSERVER_ROOT}/devices/${DEVICE_ID}/linux_app/audio_utils ${D}${bindir}/audio_utils
     fi
+    if [ -f ${WEBSERVER_ROOT}/devices/${DEVICE_ID}/linux_app/speech_utils ]; then
+        install -m 0755 ${WEBSERVER_ROOT}/devices/${DEVICE_ID}/linux_app/speech_utils ${D}${bindir}/speech_utils
+    fi
 
     # Install demos
     install -d ${D}${datadir}/${BPN}/demos
@@ -228,6 +240,10 @@ FILES:${PN} = " \
     ${sysconfdir}/webserver-oob.conf \
 "
 
+FILES:${PN}:append:am62pxx = " ${bindir}/speech_utils"
+FILES:${PN}:append:am62xx = " ${bindir}/speech_utils"
+FILES:${PN}:append:am62lxx = " ${bindir}/speech_utils"
+
 FILES:${PN}:append:am64xx = " ${bindir}/rpmsg_json ${systemd_system_unitdir}/rpmsg-json.service"
 
-PR = "r1"
+PR = "r2"

--- a/meta-ti-ml/recipes-demos/analytics-demo-data/analytics-demo-data.bb
+++ b/meta-ti-ml/recipes-demos/analytics-demo-data/analytics-demo-data.bb
@@ -4,7 +4,7 @@ LICENSE = "TI-TFL"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=9581b427bf58e35c66e06c572d472e88"
 
 SRC_URI = "git://github.com/TexasInstruments/oob-demo-assets.git;protocol=https;branch=master"
-SRCREV = "6b64cbdfd16648f1dd75dfc1ec8711c2b6559826"
+SRCREV = "2bee2f461a3b508c949d8ae0d585a9779e7181d3"
 
 do_install() {
 	CP_ARGS="-Prf --preserve=mode,timestamps --no-preserve=ownership"


### PR DESCRIPTION
Enable speech recognition using Silero en_v5 ONNX model via GStreamer + NNStreamer + ONNX Runtime to webserver-oob.

Also, bump analytics-demo-data SRCREV to include en_v5.onnx Silero model.