### PR TITLE
recipes-demos: ti-librpmsg-dma-example: Add rpmsg inference client support

### DIFF
--- a/meta-ti-foundational/recipes-demos/dsp-offload/ti-librpmsg-dma-example_1.0.bb
+++ b/meta-ti-foundational/recipes-demos/dsp-offload/ti-librpmsg-dma-example_1.0.bb
@@ -3,13 +3,15 @@ LICENSE = "TI-TFL"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=91dc4ee6d125d0aaba4e5bd2fcc50ed3"
 
 SRC_URI = "git://github.com/TexasInstruments/rpmsg-dma.git;protocol=https;branch=main"
-SRCREV = "0ade52079b8877c78992d6bc85d1edf8d284a0d4"
+SRCREV = "d0e107211275c69eda653a93a2ab3cc66b16f608"
 
 inherit cmake pkgconfig
 
-DEPENDS = "ti-librpmsg-dma fftw libsndfile1 alsa-lib"
+DEPENDS = "ti-librpmsg-dma fftw libsndfile1 alsa-lib ti-tidl-osrt json-c readline pkgconfig-native"
 
-EXTRA_OECMAKE += "-DBUILD_LIB=OFF -DBUILD_EXAMPLE=ON"
+EXTRA_OECMAKE += "-DBUILD_LIB=OFF -DBUILD_EXAMPLE=ON \
+	-DTVM_ROOT=${RECIPE_SYSROOT}${includedir}/tvm/tvm \
+	-DTVM_RUNTIME_LIB=${RECIPE_SYSROOT}${libdir}/libtvm_runtime.so"
 
 PACKAGES += "${PN}-firmware"
 RDEPENDS:${PN} += "${PN}-firmware"
@@ -20,9 +22,12 @@ FILES:${PN} += " \
 	${bindir}/rpmsg_audio_offload_example \
 	${bindir}/rpmsg_2dfft_example \
 	${bindir}/rpmsg_sigchain_biquad_example \
+	${bindir}/rpmsg_inference_example \
 	${sysconfdir}/dsp_offload.cfg \
 	${datadir}/sample_audio.wav \
 	${datadir}/2dfft_test_data \
 	${datadir}/2dfft_test_data/2dfft_expected_output_data.bin \
 	${datadir}/2dfft_test_data/2dfft_input_data.bin \
+	${datadir}/tvm_inference/json/ \
+	${datadir}/tvm_inference/input/ \
 "


### PR DESCRIPTION
Add rpmsg inference client example to the DSP offload recipe to enable support for audio enhancement pipeline: pre-processing (STFT)-> EdgeAi inference -> post-processing (ISTFT).

Also add ti-tidl-osrt, json-c, readline dependencies and cmake configuration to build rpmsg_inference_example with TVM runtime.